### PR TITLE
Only apply novalidate if there's inline or onsubmit validation

### DIFF
--- a/src/templates/_special/form-template/form.html
+++ b/src/templates/_special/form-template/form.html
@@ -27,7 +27,7 @@
         method: 'post',
         enctype: 'multipart/form-data',
         'accept-charset': 'utf-8',
-        novalidate: true,
+        novalidate: form.settings.validationOnSubmit or form.settings.validationOnFocus,
         data: {
             'submit-method': form.settings.submitMethod ?: false,
             'submit-action': form.settings.submitAction ?: false,


### PR DESCRIPTION
Somethings to consider:

1. Should there still be HTML5 browser validation if `form.settings.validationOnFocus` is off?
2. This doesn't take into account if `form.template.outputJsBase` is off