### PR TITLE
Only generate unique input value for unique forms

### DIFF
--- a/src/integrations/captchas/Javascript.php
+++ b/src/integrations/captchas/Javascript.php
@@ -61,7 +61,11 @@ class Javascript extends Captcha
 
         // Create the unique token 
         $uniqueId = uniqid(self::JAVASCRIPT_INPUT_NAME . '_', false);
-        $value = uniqid();
+
+        $value = Craft::$app->getSession()->get($sessionId);
+        if (!$value) {
+            $value = uniqid();
+        }
 
         // Save the generated input value so we can validate it properly. Also make it per-form
         Craft::$app->getSession()->set($sessionId, $value);


### PR DESCRIPTION
The validateSubmission-function fails for all non-unique forms, except the last one because `$value !== $jsset`.
The `$value` value was overwritten every time the non-unique form is rendered.

How to reproduce the issue (that is fixed by this PR):
- Create a form.
- Enable Javascript captcha form the form.
- Render the form multiple times on a page.
- Only the last form works as intended. Other forms fail because `$value !== $jsset`.