### PR TITLE
Update cached-forms.md

### DIFF
--- a/docs/template-guides/cached-forms.md
+++ b/docs/template-guides/cached-forms.md
@@ -53,7 +53,7 @@ Let's take a look at an example in action.
     // Wait until the DOM is ready
     document.addEventListener('DOMContentLoaded', (event) => {
         // Fetch the form we want to deal with
-        let $form = document.querySelector('#formie-form-{{ form.id }}');
+        let $form = document.querySelector('#{{ form.formId }}');
 
         // Find the CSRF token hidden input, so we can replace it
         let $csrfInput = $form.querySelector('input[name="CRAFT_CSRF_TOKEN"]');


### PR DESCRIPTION
Default form template uses `form.formId`

![image](https://user-images.githubusercontent.com/25124/104876020-da7efd80-59aa-11eb-87bd-00d5b0d4e52b.png)
