### PR TITLE
Fix getValue method on BaseOptionsField

### DIFF
--- a/src/fields/formfields/BaseOptionsField.php
+++ b/src/fields/formfields/BaseOptionsField.php
@@ -84,6 +84,8 @@ abstract class BaseOptionsField extends CraftBaseOptionsField
                 /** @var OptionData $selectedValue */
                 $values[] = $selectedValue->value;
             }
+
+            return $values;
         }
 
         return null;


### PR DESCRIPTION
The getValue method on BaseOptionsField doesn't return the values array when multiple options have been selected.