### PR TITLE
Allow both 0.3.0 and 0.4.0 guzzlehttp/oauth-subscriber

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ezyang/htmlpurifier": "^4.13",
         "fakerphp/faker": "1.9.1",
         "giggsey/libphonenumber-for-php": "^8.12",
-        "guzzlehttp/oauth-subscriber": "^0.3.0",
+        "guzzlehttp/oauth-subscriber": "^0.3.0 || ^0.4.0",
         "hoa/ruler": "~2.0",
         "html2text/html2text": "^4.3",
         "league/html-to-markdown": "^4.10",


### PR DESCRIPTION
Hello,

In #80 guzzlehttp/oauth-subscriber was reverted from 0.4.0 to 0.3.0, this changes that to allow both 0.3.0 and 0.4.0.

Thanks,