### PR TITLE
Fixed InfusionSoft sending number instead of phone_numbers

### DIFF
--- a/src/integrations/crm/Infusionsoft.php
+++ b/src/integrations/crm/Infusionsoft.php
@@ -414,6 +414,17 @@ class Infusionsoft extends Crm
                 ],
             ];
         }
+        
+        $number = ArrayHelper::remove($payload, 'number');
+
+        if ($number) {
+            $payload['phone_numbers'] = [
+                [
+                    'number' => $number,
+                    'field' => 'PHONE1',
+                ],
+            ];
+        }
 
         $address = array_filter([
             'country_code' => ArrayHelper::remove($payload, 'country_code'),

--- a/src/integrations/crm/Infusionsoft.php
+++ b/src/integrations/crm/Infusionsoft.php
@@ -404,23 +404,12 @@ class Infusionsoft extends Crm
             ],
         ];
 
-        $phone = ArrayHelper::remove($payload, 'phone');
+        $phone = ArrayHelper::remove($payload, 'number');
 
         if ($phone) {
             $payload['phone_numbers'] = [
                 [
                     'number' => $phone,
-                    'field' => 'PHONE1',
-                ],
-            ];
-        }
-        
-        $number = ArrayHelper::remove($payload, 'number');
-
-        if ($number) {
-            $payload['phone_numbers'] = [
-                [
-                    'number' => $number,
                     'field' => 'PHONE1',
                 ],
             ];


### PR DESCRIPTION
Currently phone number is sent as a string `"number": "value"` this fixes it so it properly sends number as a phone number.

I am not sure if this is the correct way to fix this. But the current way errors out with `{"message":"Unrecognized property: number"}` as phone numbers need to be formatted in an array like `"phone_numbers": {"number":"value","field":"PHONE1"}`. Currently `phone` is overridden, but not `number` which is what the Phone Number mapping field is set as.

Let me know if there is a better way of doing this and I will adjust.