### PR TITLE
Add option to Mailchimp integration to append tags

### DIFF
--- a/src/integrations/emailmarketing/Mailchimp.php
+++ b/src/integrations/emailmarketing/Mailchimp.php
@@ -23,6 +23,7 @@ class Mailchimp extends EmailMarketing
     // =========================================================================
 
     public $apiKey;
+    public $appendTags = false;
     public $useDoubleOptIn = false;
 
 
@@ -220,6 +221,11 @@ class Mailchimp extends EmailMarketing
                 $tags = array_filter(array_map('trim', explode(',', $tags)));
 
                 if ($tags) {
+                    if ($this->appendTags) {
+                        $existingTags = $this->_getExistingTags($emailHash);
+                        $tags = array_merge($tags, $existingTags);
+                    }
+
                     $payload = [
                         'tags' => array_map(function($tag) {
                             return ['name' => $tag, 'status' => 'active'];
@@ -358,5 +364,18 @@ class Mailchimp extends EmailMarketing
         }
 
         return $customFields;
+    }
+
+    /**
+     * Returns a list of existing member tags.
+     *
+     * @param string $emailHash
+     * @return string[]
+     */
+    private function _getExistingTags(string $emailHash): array {
+        $response = $this->request('GET', "lists/{$this->listId}/members/{$emailHash}/tags");
+        return array_map(function($tag) {
+            return $tag['name'];
+        }, $response['tags']);
     }
 }

--- a/src/templates/integrations/email-marketing/mailchimp/_form-settings.html
+++ b/src/templates/integrations/email-marketing/mailchimp/_form-settings.html
@@ -65,6 +65,13 @@
     </div>
 </integration-form-settings>
 
+{{ forms.lightswitchField({
+    label: 'Append Tags' | t('formie'),
+    id: 'appendTags',
+    name: 'appendTags',
+    instructions: 'Whether to append tags to the list of existing member tags.' | t('formie'),
+    on: form.settings.integrations[handle].appendTags ?? false,
+}) }}
 
 {{ forms.lightswitchField({
     label: 'Use Double Opt in' | t('formie'),

--- a/src/translations/en/formie.php
+++ b/src/translations/en/formie.php
@@ -922,6 +922,8 @@ return [
     'Enter your {name} client folder ID here.' => 'Enter your {name} client folder ID here.',
     'API URL' => 'API URL',
     'Enter your {name} API URL here.' => 'Enter your {name} API URL here.',
+    'Append tags' => 'Append tags',
+    'Whether to append tags to the list of existing member tags.' => 'Whether to append tags to the list of existing member tags.',
     'Use Double Opt in' => 'Use Double Opt in',
     'Enter your {name} Client ID key here.' => 'Enter your {name} Client ID key here.',
     'API App ID' => 'API App ID',


### PR DESCRIPTION
Adds an "Append Tags" option in Mailchimp integration that when enabled merges existing member tags with any tags specified by the form.  This is useful so you don't lose existing tags the user already exists in the mailing list (e.g. if you have a single mailing list but multiple forms to register for different products).

I'm not sure if "Append Tags" is the most user-friendly label, maybe something like "Preserve existing tags" or something would be more clear - I'm happy to change it. Thank you!