### PR TITLE
Freshdesk integration: Fix validation error for tickets

### DIFF
--- a/src/integrations/crm/Freshdesk.php
+++ b/src/integrations/crm/Freshdesk.php
@@ -413,9 +413,14 @@ class Freshdesk extends Crm
                     // Directly modify the field values first
                     $ticketFields = $this->_prepCustomFields($ticketValues);
 
-                    $ticketPayload = array_merge($ticketValues, [
-                        'custom_fields' => $ticketFields,
-                    ]);
+                    // Only add custom fields if array not empty to prevent validation error
+                    if ($ticketFields) {
+                        $ticketPayload = array_merge($ticketValues, [
+                            'custom_fields' => $ticketFields,
+                        ]);
+                    } else {
+                        $ticketPayload = $ticketValues;
+                    }
 
                     // Extra payload prep - some fields are finnicky
                     if (isset($ticketPayload['status'])) {


### PR DESCRIPTION
Fixes bug where validation error was thrown for tickets when no custom fields were used.
The fix was already present for Contacts.