### PR TITLE
Use new Campaign integration method

### DIFF
--- a/src/integrations/emailmarketing/Campaign.php
+++ b/src/integrations/emailmarketing/Campaign.php
@@ -106,6 +106,8 @@ class Campaign extends EmailMarketing
                     Integration::error($this, Craft::t('formie', 'Unable to save contact: “{errors}”.', [
                         'errors' => Json::encode($contact->getErrors()),
                     ]), true);
+                    
+                    return false;
                 }
             } 
             // TODO: remove this in Formie v3, assuming it requires Craft 5, in which case Campaign v3 will be required.

--- a/src/integrations/emailmarketing/Campaign.php
+++ b/src/integrations/emailmarketing/Campaign.php
@@ -100,7 +100,7 @@ class Campaign extends EmailMarketing
 
             // The `createAndSubscribeContact` method was added in Campaign v2.1.0.
             if (method_exists(Campaign::$plugin->forms, 'createAndSubscribeContact')) {
-                $contact = Campaign::$plugin->forms->createAndSubscribeContact($email, $list, 'formie', $this->referrer);
+                $contact = Campaign::$plugin->forms->createAndSubscribeContact($email, $fieldValues, $list, 'formie', $this->referrer);
                 
                 if ($contact->hasErrors()) {
                     Integration::error($this, Craft::t('formie', 'Unable to save contact: “{errors}”.', [
@@ -117,10 +117,10 @@ class Campaign extends EmailMarketing
     
                 if ($contact === null) {
                     $contact = new ContactElement();
+                    $contact->email = $email;
                 }
     
                 // Set field values
-                $contact->email = $email;
                 $contact->setFieldValues($fieldValues);
     
                 // If subscribe verification required


### PR DESCRIPTION
Following up on https://github.com/verbb/formie/issues/837, thanks to @sarahschuetz, I've made it easier to integrate with the Campaign plugin going forward. This PR uses the new `FormsService::createAndSubscribeContact` method, falling back to the manual way of doing things if the method does not exist (if an older version of Campaign is installed). I also added a `TODO` to remind you to remove the manual approach in the next major version of Formie.