### PR TITLE
Draft: fix(integrations): update Mailjet form settings, 1138

### DIFF
--- a/src/templates/integrations/email-marketing/mailjet/_form-settings.html
+++ b/src/templates/integrations/email-marketing/mailjet/_form-settings.html
@@ -12,55 +12,56 @@
     :value="get(form, 'settings.integrations.{{ handle }}.optInField')"
 ></field-select>
 
-<integration-form-settings handle="{{ handle }}" :form-settings="{{ formSettings | json_encode }}" source="{{ listId }}" inline-template>
-    <div>
-        <div class="field">
-            <div class="heading">
-                <label id="sourceId-label" for="sourceId" class="required">{{ 'List' | t('formie') }}</label>
+<integration-form-settings handle="{{ handle }}" :form-settings="{{ formSettings | json_encode }}" source="{{ listId }}">
+<template
+    v-slot="{ get, isEmpty, input, settings, sourceId, loading, refresh, error, errorMessage, getSourceFields }">
+  <div class="field">
+    <div class="heading">
+      <label id="sourceId-label" for="sourceId" class="required">{{ 'List' | t('formie') }}</label>
 
-                <div class="instructions">
-                    <p>{{ 'Select your {name} list to create contacts on.' | t('formie', { name: integration.displayName() }) }}</p>
-                </div>
-            </div>
-
-            <div class="input ltr">
-                <div class="select">
-                    <select v-model="sourceId" name="listId" required>
-                        <option value="">{{ 'Select an option' | t('formie') }}</option>
-
-                        <option v-for="(option, index) in get(settings, 'lists')" :key="index" :value="option.id">${ option.name }</option>
-                    </select>
-                </div>
-
-                <button class="btn fui-btn-transparent" :class="{ 'fui-loading fui-loading-sm': loading }" data-icon="refresh" @click.prevent="refresh"></button>
-            </div>
-
-            <ul v-if="!isEmpty(get(form, 'settings.integrations.{{ handle }}.errors.listId'))" class="errors" v-cloak>
-                <li v-for="(error, index) in get(form, 'settings.integrations.{{ handle }}.errors.listId')" :key="index">
-                    ${ error }
-                </li>
-            </ul>
-        </div>
-
-        <div v-if="error" class="error" style="margin-top: 10px;" v-cloak>
-            <span data-icon="alert"></span>
-            <span v-html="errorMessage"></span>
-        </div>
-
-        <integration-field-mapping
-            label="{{ 'Field Mapping' | t('formie') }}"
-            instructions="{{ 'Choose how your form fields should map to your {name} fields.' | t('formie', { name: integration.displayName() }) }}"
-            id="field-mapping"
-            name-label="{{ integration.displayName() }}"
-            name="fieldMapping"
-            :value="get(form, 'settings.integrations.{{ handle }}.fieldMapping')"
-            :rows="getSourceFields('lists')"
-        ></integration-field-mapping>
-
-        <ul v-if="!isEmpty(get(form, 'settings.integrations.{{ handle }}.errors.fieldMapping'))" class="errors" v-cloak>
-            <li v-for="(error, index) in get(form, 'settings.integrations.{{ handle }}.errors.fieldMapping')" :key="index">
-                ${ error }
-            </li>
-        </ul>
+      <div class="instructions">
+        <p>{{ 'Select your {name} list to create contacts on.' | t('formie', { name: integration.displayName() }) }}</p>
+      </div>
     </div>
+
+    <div class="input ltr">
+      <div class="select">
+        <select :value="sourceId" @input="input('sourceId', $event.target.value)"  name="listId" required>
+          <option value="">{{ 'Select an option' | t('formie') }}</option>
+
+          <option v-for="(option, index) in get(settings, 'lists')" :key="index" :value="option.id">${ option.name }</option>
+        </select>
+      </div>
+
+      <button class="btn fui-btn-transparent" :class="{ 'fui-loading fui-loading-sm': loading }" data-icon="refresh" @click.prevent="refresh"></button>
+    </div>
+
+    <ul v-if="!isEmpty(get(form, 'settings.integrations.{{ handle }}.errors.listId'))" class="errors" v-cloak>
+      <li v-for="(error, index) in get(form, 'settings.integrations.{{ handle }}.errors.listId')" :key="index">
+        ${ error }
+      </li>
+    </ul>
+  </div>
+
+  <div v-if="error" class="error" style="margin-top: 10px;" v-cloak>
+    <span data-icon="alert"></span>
+    <span v-html="errorMessage"></span>
+  </div>
+
+  <integration-field-mapping
+      label="{{ 'Field Mapping' | t('formie') }}"
+      instructions="{{ 'Choose how your form fields should map to your {name} fields.' | t('formie', { name: integration.displayName() }) }}"
+      id="field-mapping"
+      name-label="{{ integration.displayName() }}"
+      name="fieldMapping"
+      :value="get(form, 'settings.integrations.{{ handle }}.fieldMapping')"
+      :rows="getSourceFields('lists')"
+  ></integration-field-mapping>
+
+  <ul v-if="!isEmpty(get(form, 'settings.integrations.{{ handle }}.errors.fieldMapping'))" class="errors" v-cloak>
+    <li v-for="(error, index) in get(form, 'settings.integrations.{{ handle }}.errors.fieldMapping')" :key="index">
+      ${ error }
+    </li>
+  </ul>
+</template>
 </integration-form-settings>


### PR DESCRIPTION
To make the form settings work within the form integrations tab, we needed to update the form settings to use the Vue template. This will show the list select and the field mapping correctly. So the form can be saved.


I have to test this finally.

Fixes #1138