### PR TITLE
fix(docs): correct closing tag for renderField()

### DIFF
--- a/docs/template-guides/available-variables.md
+++ b/docs/template-guides/available-variables.md
@@ -46,7 +46,7 @@ Renders a single field, taking into account custom [Form Templates](docs:feature
 
 {% for field in form.getCustomFields() %}
     {{ craft.formie.renderField(form, field) }}
-{% endif %}
+{% endfor %}
 ```
 
 


### PR DESCRIPTION
The twig tag `for` has to be ended with `endfor`. There was an error where it was `endif` without any starting `if` in the code example.