### PR TITLE
Correct compliance for aria-hidden

### DIFF
--- a/src/base/FormFieldTrait.php
+++ b/src/base/FormFieldTrait.php
@@ -782,7 +782,7 @@ trait FormFieldTrait
         if ($key === 'fieldRequired') {
             return new HtmlTag('span', [
                 'class' => 'fui-required',
-                'aria-hidden' => true,
+                'aria-hidden' => 'true',
             ]);
         }
 


### PR DESCRIPTION
ARIA attributes starting with aria- must contain valid values. These values must be spelled correctly and correspond to values that make sense for a particular attribute in order to perform the intended accessibility function.

When passing a boolean value of true for aria-hidden on required fields, the output HTML contains the attribute "aria-hidden" instead of the required "aria-hidden='true'". This registers as an accessibility issue when performing a Lighthouse page audit.

Changing from a boolean value to a string results in the correct aria-hidden value for required field indicators.