### PR TITLE
Fix syntax error in doc example

### DIFF
--- a/docs/developers/field.md
+++ b/docs/developers/field.md
@@ -418,7 +418,7 @@ Or, maybe we only want a field required when another field is a certain value.
 Event::on(Submission::class, Submission::EVENT_DEFINE_RULES, function(SubmissionRulesEvent $event) {
     $event->rules[] = [['field:emailAddress'], 'required', 'when' => function($model) {
         return $model->subscribeMe;
-    }]];
+    }];
 });
 ```
 


### PR DESCRIPTION
The custom validation example that uses the when attribute has a syntax error in the example which doesn't parse correctly in PHP.