### PR TITLE
Microsoft Dynamics 365 integration additions and improvements

### DIFF
--- a/src/base/Integration.php
+++ b/src/base/Integration.php
@@ -727,7 +727,7 @@ abstract class Integration extends SavableComponent implements IntegrationInterf
     {
         $response = $this->getClient()->request($method, ltrim($uri, '/'), $options);
 
-        return Json::decode((string)$response->getBody());
+        return Json::decode($response->getBody()->getContents());
     }
 
     /**

--- a/src/events/MicrosoftDynamics365RequiredLevelsEvent.php
+++ b/src/events/MicrosoftDynamics365RequiredLevelsEvent.php
@@ -1,0 +1,13 @@
+<?php
+namespace verbb\formie\events;
+
+use yii\base\Event;
+
+class MicrosoftDynamics365RequiredLevelsEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    public array $requiredLevels;
+
+}

--- a/src/events/MicrosoftDynamics365TargetSchemasEvent.php
+++ b/src/events/MicrosoftDynamics365TargetSchemasEvent.php
@@ -1,0 +1,13 @@
+<?php
+namespace verbb\formie\events;
+
+use yii\base\Event;
+
+class MicrosoftDynamics365TargetSchemasEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    public array $targetSchemas;
+
+}

--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -1,6 +1,8 @@
 <?php
 namespace verbb\formie\integrations\crm;
 
+use verbb\formie\events\MicrosoftDynamics365RequiredLevelsEvent;
+use verbb\formie\events\MicrosoftDynamics365TargetSchemasEvent;
 use verbb\formie\Formie;
 use verbb\formie\base\Crm;
 use verbb\formie\base\Integration;
@@ -40,6 +42,11 @@ class MicrosoftDynamics365 extends Crm
 
     private $_entityOptions = [];
 
+    // Constants
+    // =========================================================================
+
+    public const EVENT_MODIFY_REQUIRED_LEVELS = 'modifyRequiredLevels';
+    public const EVENT_MODIFY_TARGET_SCHEMAS = 'modifyTargetSchemas';
 
     // OAuth Methods
     // =========================================================================
@@ -222,7 +229,7 @@ class MicrosoftDynamics365 extends Crm
                 $accountPayload = $accountValues;
 
                 if ($contactId) {
-                    $accountPayload['primarycontactid@odata.bind'] = 'contacts(' . $contactId . ')';
+                    $accountPayload['primarycontactid@odata.bind'] = $this->_formatLookupValue('contacts', $contactId);
                 }
 
                 $response = $this->deliverPayload($submission, 'accounts?$select=accountid', $accountPayload);
@@ -247,7 +254,8 @@ class MicrosoftDynamics365 extends Crm
                 $leadPayload = $leadValues;
 
                 if ($contactId) {
-                    $leadPayload['parentcontactid@odata.bind'] = 'contacts(' . $contactId . ')';
+                    $leadPayload['parentcontactid@odata.bind'] = $this->_formatLookupValue('contacts', $contactId);
+                    $leadPayload['customerid_contact@odata.bind'] = $this->_formatLookupValue('contacts', $contactId);
                 }
 
                 $response = $this->deliverPayload($submission, 'leads?$select=leadid', $leadPayload);
@@ -272,11 +280,11 @@ class MicrosoftDynamics365 extends Crm
                 $opportunityPayload = $opportunityValues;
 
                 if ($contactId) {
-                    $accountPayload['parentcontactid@odata.bind'] = 'contacts(' . $contactId . ')';
+                    $accountPayload['parentcontactid@odata.bind'] = $this->_formatLookupValue('contacts', $contactId);
                 }
 
                 if ($accountId) {
-                    $accountPayload['parentaccountid@odata.bind'] = 'accounts(' . $accountId . ')';
+                    $accountPayload['parentaccountid@odata.bind'] = $this->_formatLookupValue('accounts', $accountId);
                 }
 
                 $response = $this->deliverPayload($submission, 'opportunities?$select=opportunityid', $opportunityPayload);
@@ -310,11 +318,23 @@ class MicrosoftDynamics365 extends Crm
      */
     public function request(string $method, string $uri, array $options = [])
     {
-        // Dynamics doesn't return a response for POST requests by default. Riiiiight...
-        if ($method === 'POST') {
-            $options['headers'] = [
-                'Prefer' => 'return=representation',
-            ];
+        // Recommended headers to pass for all web API requests
+        // https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/compose-http-requests-handle-errors#http-headers
+        $defaultOptions = [
+            'headers' => [
+                'Accept' => 'application/json',
+                'OData-MaxVersion' => '4.0',
+                'OData-Version' => '4.0',
+                'If-None-Match' => null
+            ]
+        ];
+
+        $options = ArrayHelper::merge($defaultOptions, $options);
+
+        // Ensure a proper response is returned on POST/PATCH operations
+        // https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/compose-http-requests-handle-errors#prefer-headers
+        if ($method === 'POST' || $method === 'PATCH') {
+            $options['headers']['Prefer'] = 'return=representation';
         }
 
         return parent::request($method, $uri, $options);
@@ -383,6 +403,7 @@ class MicrosoftDynamics365 extends Crm
             'Integer' => IntegrationField::TYPE_NUMBER,
             'Boolean' => IntegrationField::TYPE_BOOLEAN,
             'Money' => IntegrationField::TYPE_FLOAT,
+            'Date' => IntegrationField::TYPE_DATE,
             'DateTime' => IntegrationField::TYPE_DATETIME,
         ];
 
@@ -394,13 +415,51 @@ class MicrosoftDynamics365 extends Crm
      */
     private function _getEntityFields($entity)
     {
+        $metadataAttributesForSelect = [
+            'AttributeType',
+            'IsCustomAttribute',
+            'IsValidForCreate',
+            'IsValidForUpdate',
+            'CanBeSecuredForCreate',
+            'CanBeSecuredForUpdate',
+            'LogicalName',
+            'DisplayName',
+            'RequiredLevel'
+        ];
+
         // Fetch all defined fields on the entity
         // https://docs.microsoft.com/en-us/dynamics365/customer-engagement/web-api/contact?view=dynamics-ce-odata-9
         // https://docs.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/entities/contact?view=op-9-1#BKMK_Address1_Telephone1
-        $response = $this->request('GET', "EntityDefinitions(LogicalName='$entity')?\$select=Attributes&\$expand=Attributes(\$select=AttributeType,IsCustomAttribute,IsValidForCreate,IsValidForUpdate,CanBeSecuredForCreate,CanBeSecuredForUpdate,LogicalName,SchemaName,DisplayName,RequiredLevel)");
+        $metadata = $this->request('GET', $this->_getEntityDefinitionsUri($entity), [
+            'query' => [
+                '$select' => 'Attributes',
+                '$expand' => 'Attributes($select='. implode(',', $metadataAttributesForSelect) . ')'
+            ]
+        ]);
+
+        // We also need to query DateTime attribute data to check if any are DateOnly
+        $dateTimeAttributes = $this->request('GET', $this->_getEntityDefinitionsUri($entity, 'DateTime'), [
+            'query' => [
+                '$select' => 'SchemaName,LogicalName,DateTimeBehavior'
+            ]
+        ]);
+
+        $dateTimeBehaviourValues = ArrayHelper::map($dateTimeAttributes, 'MetadataId','DateTimeBehavior.Value');
 
         $fields = [];
-        $attributes = $response['Attributes'] ?? [];
+        $attributes = $metadata['Attributes'] ?? [];
+
+        // Default to SystemRequired and ApplicationRequired
+        $requiredLevels = [
+            'SystemRequired',
+            'ApplicationRequired'
+        ];
+
+        $event = new MicrosoftDynamics365RequiredLevelsEvent([
+            'requiredLevels' => $requiredLevels,
+        ]);
+
+        $this->trigger(self::EVENT_MODIFY_REQUIRED_LEVELS, $event);
 
         foreach ($attributes as $field) {
             $label = $field['DisplayName']['UserLocalizedLabel']['Label'] ?? '';
@@ -409,6 +468,7 @@ class MicrosoftDynamics365 extends Crm
             $requiredLevel = $field['RequiredLevel']['Value'] ?? 'None';
             $type = $field['AttributeType'] ?? '';
             $odataType = $field['@odata.type'] ?? '';
+            $metadataId = $field['MetadataId'] ?? '';
 
             // Pick the correct field handle, depending on custom fields
             if ($customField) {
@@ -420,19 +480,27 @@ class MicrosoftDynamics365 extends Crm
             $key = $handle;
 
             $excludedTypes = [
-                'Virtual',
-                'Uniqueidentifier',
                 'Customer',
                 'EntityName',
+                'State',
+                'Uniqueidentifier',
+                'Virtual',
             ];
 
-            if (!$label || !$handle || !$canCreate || in_array($type, $excludedTypes)) {
+            if (!$label || !$handle || !$canCreate || in_array($type, $excludedTypes, true)) {
                 continue;
             }
 
             // Relational fields need a special handle
             if ($odataType === '#Microsoft.Dynamics.CRM.LookupAttributeMetadata') {
-                $handle = $handle . '@odata.bind';
+                $handle .= '@odata.bind';
+            }
+
+            // DateTime attributes, just because the AttributeType is DateTime doesn't mean it actually accepts one!
+            // If a field DateTimeBehaviour is set to DateOnly, it will not accept DateTime values ever!
+            // https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/behavior-format-date-time-attribute
+            if ($type === 'DateTime' && $dateTimeBehaviourValues[$metadataId] === 'DateOnly') {
+                $type = 'Date';
             }
 
             // Index by handle for easy lookup with PickLists
@@ -440,12 +508,30 @@ class MicrosoftDynamics365 extends Crm
                 'handle' => $handle,
                 'name' => $label,
                 'type' => $this->_convertFieldType($type),
-                'required' => ($requiredLevel === 'SystemRequired' || $requiredLevel === 'ApplicationRequired'),
+                'required' => in_array($requiredLevel, $event->requiredLevels, true),
             ]);
         }
 
+        // Add default true/false values for boolean fields
+        foreach ($fields as $field) {
+            if ($field->type === IntegrationField::TYPE_BOOLEAN) {
+                $field->options = [
+                    'label' => Craft::t('formie', 'Default options'),
+                    'options' => [
+                        ['label' => Craft::t('formie', 'True'), 'value' => 'true'],
+                        ['label' => Craft::t('formie', 'False'), 'value' => 'false']
+                    ]
+                ];
+            }
+        }
+
         // Do another call for PickList fields, to populate any set options to pick from
-        $response = $this->request('GET', "EntityDefinitions(LogicalName='$entity')/Attributes/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?\$select=IsCustomAttribute,LogicalName,SchemaName&\$expand=GlobalOptionSet(\$select=Options)");
+        $response = $this->request('GET', $this->_getEntityDefinitionsUri($entity, 'Picklist'), [
+            'query' => [
+                '$select' => 'IsCustomAttribute,LogicalName,SchemaName',
+                '$expand' => 'GlobalOptionSet($select=Options)'
+            ]
+        ]);
         $pickListFields = $response['value'] ?? [];
 
         foreach ($pickListFields as $pickListField) {
@@ -483,14 +569,14 @@ class MicrosoftDynamics365 extends Crm
         }
 
         // Do the same thing for any fields with an Owner, we have to do multiple queries.
-        // This be be for multiple entities, so have some cache.
+        // This is for multiple entities, so have some cache.
         $this->_getEntityOwnerOptions($entity, $fields);
 
         // Reset array keys
         $fields = array_values($fields);
 
         // Sort alphabetically by label
-        usort($fields, function($a, $b) {
+        usort($fields, static function($a, $b) {
             return strcmp($a->name, $b->name);
         });
 
@@ -503,7 +589,11 @@ class MicrosoftDynamics365 extends Crm
     private function _getEntityOwnerOptions($entity, &$fields)
     {
         // Get all the fields that are relational
-        $response = $this->request('GET', "EntityDefinitions(LogicalName='$entity')/Attributes/Microsoft.Dynamics.CRM.LookupAttributeMetadata?\$select=IsCustomAttribute,LogicalName,SchemaName,Targets");
+        $response = $this->request('GET', $this->_getEntityDefinitionsUri($entity, 'Lookup'), [
+            'query' => [
+                '$select' => 'IsCustomAttribute,LogicalName,SchemaName,Targets'
+            ]
+        ]);
         $relationFields = $response['value'] ?? [];
 
         // Define a schema so that we can query each entity according to the target (index)
@@ -556,6 +646,14 @@ class MicrosoftDynamics365 extends Crm
             ],
         ];
 
+        $event = new MicrosoftDynamics365TargetSchemasEvent([
+            'targetSchemas' => $targetSchemas,
+        ]);
+
+        $this->trigger(self::EVENT_MODIFY_TARGET_SCHEMAS, $event);
+
+        $targetSchemas = ArrayHelper::merge($targetSchemas, $event->targetSchemas);
+
         // Populate our cached entity options, cached across multiple calls because we only need to
         // fetch the collection once, for each entity type. Subsequent fields can re-use the options.
         foreach ($relationFields as $relationField) {
@@ -584,8 +682,10 @@ class MicrosoftDynamics365 extends Crm
                 // Fetch the entities and use the schema options to store. Be sure to limit and be performant.
                 $response = $this->request('GET', $targetSchema['entity'], [
                     'query' => [
-                        '$top' => '100',
+                        '$top' => $targetSchema['limit'] ?? '100',
                         '$select' => implode(',', $select),
+                        '$orderby' => $targetSchema['orderby'] ?? null,
+                        '$filter' => $targetSchema['filter'] ?? null
                     ],
                 ]);
 
@@ -593,10 +693,8 @@ class MicrosoftDynamics365 extends Crm
 
                 foreach ($entities as $entity) {
                     // Special-case for systemusers
-                    if ($target === 'systemuser') {
-                        if (isset($entity['applicationid'])) {
-                            continue;
-                        }
+                    if ($target === 'systemuser' && isset($entity['applicationid'])) {
+                        continue;
                     }
 
                     $label = $entity[$targetSchema['label']] ?? '';
@@ -604,7 +702,7 @@ class MicrosoftDynamics365 extends Crm
 
                     $this->_entityOptions[$target][] = [
                         'label' => $label,
-                        'value' => $targetSchema['entity'] . '(' . $value . ')',
+                        'value' => $this->_formatLookupValue($targetSchema['entity'], $value),
                     ];
                 }
             }
@@ -626,7 +724,7 @@ class MicrosoftDynamics365 extends Crm
             foreach ($targets as $target) {
                 // Get the options for this field
                 if (isset($this->_entityOptions[$target])) {
-                    $options = array_merge($options, $this->_entityOptions[$target]);
+                    $options = ArrayHelper::merge($options, $this->_entityOptions[$target]);
                 }
             }
 
@@ -643,5 +741,35 @@ class MicrosoftDynamics365 extends Crm
                 'options' => $options,
             ];
         }
+    }
+
+    /**
+     * Formats lookup values as entityname(GUID)
+     *
+     * @param $entity
+     * @param $value
+     * @return string
+     */
+    private function _formatLookupValue($entity, $value): string
+    {
+        return $entity . '(' . $value . ')';
+    }
+
+    /**
+     * Format EntityDefintions uri request path
+     *
+     * @param $entity
+     * @param $type
+     * @return string
+     */
+    private function _getEntityDefinitionsUri($entity, $type = null): string
+    {
+        $path = "EntityDefinitions(LogicalName='$entity')";
+
+        if ($type) {
+            $path .= "/Attributes/Microsoft.Dynamics.CRM.{$type}AttributeMetadata";
+        }
+
+        return $path;
     }
 }


### PR DESCRIPTION
Following on from https://github.com/verbb/formie/issues/1262. This PR makes some changes and additions to the Microsoft Dynamics 365 integration class. These are mostly modifications made to the extended class I use, but hoping to contribute back to the main project if it helps other Dynamics 365 users.

This PR does the following:

1. Update all GuzzleClient requests to use the query option to pass in parameters, this avoids having to escape the `$` sign when including in the URI value and also a bit cleaner to see the parameters
2. Call `$response->getBody()->getContents()` in base integration class for the request function. You do not need to cast the response as a string as this is done for you with this method.
3. Allow RequiredLevel of fields that get marked as required by the field mapping to be customised. I have found with our CRM some ApplicationRequired rules are problematic. The API doesn't stop you so you can bypass these and hence being able to allow Formie to not force it either is useful. For example, I just set "SystemRequired". Arguably, if you have some strange rules these should be corrected via business rules at the CRM level, but being able to allow Formie to not mark them as required might be helpful?
4. Handle DateOnly DateTime fields with an additional metadata query to get all DateTime fields and check their DateTimeBehavior. If a field is set to "DateOnly", the type of field should be set to "Date" not "DateTime, see #1265 for more info and details on why this can be a problem without handling.
5. Allow the targetSchemas array in the main integration class to be modified or appended to via an event for customisation.
6. When querying for lookup values with targetSchemas, allow the additional parameters of `orderby` and `filter` to be used if required (see event example).
7. Allow `limit` to be specified on lookup queries (via event) to override the default value of 100, but fallback to `100` if not set to maintain performance.
8. Add default true/false values for boolean type fields, so they can be populated in the mapping without needing a field assigned. Resolves #1250
9. Add a reusable function to format lookup values to the format `pluralentityname(GUID)` to save duplicating string concat each time.
10. Merge the systemuser and isset condition for checking for the presence of a applicationid as it can be merged with the parent one.
11. Declare the usort function as static for a small performance benefit
12. Map `customerid_contact` on lead payload (I believe this is a standard CRM field and therefore should be safe to be included) for any CRM.
13. Exclude the State AttributeType to prevent this field being forced in the mapping: https://github.com/verbb/formie/issues/1276
14. Set the recommended headers for all Microsoft Dynamics 365 API requests: https://github.com/verbb/formie/issues/1277.
15. The `Prefer:  "return=representation"` header should also be set for PATCH requests. While the Formie integration does not use PATCH requests anywhere, if calling the integration client for custom reasons, this is useful.
16. Use AttributeType for checking specific field types rather than odata.type, due to odata.type value being longer and less readable. For the lookup condition to append `@odata.bind` the odata.type should be used because some Lookups don't have an attribute type of Lookup! Nice.
17. Use a function to provide EntityDefinitions URI paths for each entity and requirement. Prevents long lines for Guzzle URI values and shortens typing the same path out each time, where the type value just changes.


### Events example

This PR adds two events for allowing modifications without needing to modify the original integration directly.

For the target schema modifications event, you can implement something like the example below. This allows you to override or add additional target schemas.

* Adding will allow you to pull custom lookup fields not covered in the main array in the integration class by adding a new entity as the key with the correct properties.
* Overwriting will allow you modify any originally included schemas with additional properties if required, without having to change the main integration class. This is possible as an ArrayHelper::merge() call is used and the contents of $event->targetSchemas would take priority when merged over the original.

```php
Event::on(
	MicrosoftDynamics365::class,
	MicrosoftDynamics365::EVENT_MODIFY_TARGET_SCHEMAS,
	static function(MicrosoftDynamics365TargetSchemasEvent $event) {
		$event->targetSchemas = [
			// Extra filter to pull active users and service accounts
			'systemuser' => [
				'filter' => "isdisabled eq false and invitestatuscode eq 4 or accessmode eq 4",
			],
                        // Modify original campaign entity with orderby and limit
			'campaign' => [
				'orderby' => 'createdon desc',
				'limit' => '150',
			],
                       // Custom entity to include on relational fields fetch
			'ccl1000_enquirytype' => [
				'entity' => 'ccl1000_enquirytypes',
				'label' => 'ccl1000_name',
				'value' => 'ccl1000_enquirytypeid'
			]
		];
	}
);
```

For the required levels you can overwrite the default array with your own requirements. E.g. if I want to just make SystemRequired fields required.

```php
Event::on(
	MicrosoftDynamics365::class,
	MicrosoftDynamics365::EVENT_MODIFY_REQUIRED_LEVELS,
	static function(MicrosoftDynamics365RequiredLevelsEvent $event) {
		$event->requiredLevels = ['SystemRequired'];
	}
);
```

The only area I can't really resolve is https://github.com/verbb/formie/issues/1251. So I've made the additions to maintain the existing if customField logic for now, however we have extended the CRM integration class and removed this logic in all places as it doesn't work for us and selects the wrong values for some fields, there is seemingly no consistency about it either, however trying to fix it by logic, will most certainly break other integrations, because our CRM environment may be different to others.

My assessment of being able to reliably fix this, is obtaining the CSDL metadata of a CRM environment and looking up property names via this. This is the single source of truth for what the correct name should be. Regardless of what the internet says about SchemaName or LogicalName, whatever the CSDL returns will be correct, which can be obtained:

A request like:

```
{{webapiurl}}$metadata
```

Will return the full metadata for a CRM environment. This however will be everything and you cannot filter it as it's just an XML file. It would need to be cached because fetching it each time will be expensive for time and performance. You would then also need to do XML parsing, as you cannot fetch it in JSON or any other format. So it is not ideal, but having some form of single source of truth is likely the only way to solve it reliably as the response will be correct for the CRM environment.
