### PR TITLE
Allow queue job description to be overridden

### DIFF
--- a/src/jobs/SendNotification.php
+++ b/src/jobs/SendNotification.php
@@ -25,14 +25,6 @@ class SendNotification extends BaseJob
     /**
      * @inheritDoc
      */
-    public function getDescription(): string
-    {
-        return Craft::t('formie', 'Sending form notification.');
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function execute($queue)
     {
         $this->setProgress($queue, 0);
@@ -81,5 +73,16 @@ class SendNotification extends BaseJob
         }
 
         $this->setProgress($queue, 1);
+    }
+
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    protected function defaultDescription(): string
+    {
+        return Craft::t('formie', 'Sending form notification.');
     }
 }

--- a/src/jobs/TriggerIntegration.php
+++ b/src/jobs/TriggerIntegration.php
@@ -26,14 +26,6 @@ class TriggerIntegration extends BaseJob
     /**
      * @inheritDoc
      */
-    public function getDescription(): string
-    {
-        return Craft::t('formie', 'Triggering form “{handle}” integration.', ['handle' => $this->integration->handle]);
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function execute($queue)
     {
         $this->setProgress($queue, 0);
@@ -70,5 +62,16 @@ class TriggerIntegration extends BaseJob
         }
 
         $this->setProgress($queue, 1);
+    }
+
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    protected function defaultDescription(): string
+    {
+        return Craft::t('formie', 'Triggering form “{handle}” integration.', ['handle' => $this->integration->handle]);
     }
 }


### PR DESCRIPTION
Queue job descriptions currently cannot be overridden if called from another module.

This allows the description to be set to something else if required, by setting a default description, allowing a description value to be passed when calling the queue job e.g.

```php
Queue::push(new TriggerIntegration([
    'submissionId' => $submission->id,
    'integration' => $integration,
    'description' => 'test'
]));
```

Currently, the description value is ignored.