### PR TITLE
Microsoft Dynamics 365: Order fields in mapping by required status first followed by name ASC

### DIFF
--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -575,10 +575,8 @@ class MicrosoftDynamics365 extends Crm
         // Reset array keys
         $fields = array_values($fields);
 
-        // Sort alphabetically by label
-        usort($fields, static function($a, $b) {
-            return strcmp($a->name, $b->name);
-        });
+        // Sort by required field and then name
+        ArrayHelper::multisort($fields, ['required', 'name'], [SORT_DESC, SORT_ASC]);
 
         return $fields;
     }


### PR DESCRIPTION
Bit of an opinionated change, but I found this useful. Depending on the amount of fields you have marked as required and the amount of fields per entity, sometimes it's a little difficult to see the required fields and I often found myself missing such fields, getting a save error, then scrolling down a long list.

This changes the order of the fields in the mapping to be first by the required value i.e. true, then by name A-Z. This means that all required fields marked in the model are at the top of each entity, followed by all other fields in A-Z which aren't required, maintaining a logical order.

I stole this idea from Zapier, because their Microsoft Dynamics 365 CRM integration does this and I found it to be quite useful, given you must populate required fields and if they happen be quite spread out, it can get a bit crazy.

![image](https://user-images.githubusercontent.com/8067792/219873729-725f564a-b45f-4d63-8f39-dfc1a5765756.png)

Note on the lead that key enquiry fields are at the top despite beginning with the letter `E`, this is due to the required status, then all other fields follow A-Z.

Just something that help others, particularly when mapping multiple entities and having a lot of fields presented.
