### PR TITLE
Microsoft Dynamics 365: Prevent a PATCH request from creating a record if it doesn't exist

### DIFF
--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -337,6 +337,12 @@ class MicrosoftDynamics365 extends Crm
             $options['headers']['Prefer'] = 'return=representation';
         }
 
+        // Prevent create when using upsert
+        // https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/perform-conditional-operations-using-web-api#prevent-create-in-upsert
+        if ($method === 'PATCH') {
+            $options['headers']['If-Match'] = '*';
+        }
+
         return parent::request($method, $uri, $options);
     }
 


### PR DESCRIPTION
An extra header for PATCH requests if using custom integration request calls.

This prevents a PATCH request from creating a record if the GUID provided doesn't exist. Currently, without this a PATCH request using a GUID that doesn't exist creates a record, which is probably in most cases not desirable. Instead with this header a 404 not found would occur preventing an operation.