### PR TITLE
Microsoft Dynamics 365: Declare convertFieldType as protected rather than private

### DIFF
--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -388,13 +388,13 @@ class MicrosoftDynamics365 extends Crm
     }
 
 
-    // Private Methods
+    // Protected Methods
     // =========================================================================
 
     /**
      * @inheritDoc
      */
-    private function _convertFieldType($fieldType)
+    protected function convertFieldType($fieldType)
     {
         $fieldTypes = [
             'Decimal' => IntegrationField::TYPE_FLOAT,
@@ -409,6 +409,9 @@ class MicrosoftDynamics365 extends Crm
 
         return $fieldTypes[$fieldType] ?? IntegrationField::TYPE_STRING;
     }
+
+    // Private Methods
+    // =========================================================================
 
     /**
      * @inheritDoc
@@ -507,7 +510,7 @@ class MicrosoftDynamics365 extends Crm
             $fields[$key] = new IntegrationField([
                 'handle' => $handle,
                 'name' => $label,
-                'type' => $this->_convertFieldType($type),
+                'type' => $this->convertFieldType($type),
                 'required' => in_array($requiredLevel, $event->requiredLevels, true),
             ]);
         }


### PR DESCRIPTION
Currently if extending the Microsoft Dynamics 365 integration class, you will have to redeclare the _convertFieldTypes function, as it is private and is used in _getEntityFields call. However given this shouldn't need to change too much, consider having it as protected rather than private, so it can be used in an extended class without having to redeclare in the extended class.