### PR TITLE
Missing Client definition for Microsoft Dynamics 365 integration

### DIFF
--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -21,6 +21,8 @@ use TheNetworg\OAuth2\Client\Provider\Azure;
 
 use Throwable;
 
+use GuzzleHttp\Client;
+
 class MicrosoftDynamics365 extends Crm
 {
     // Constants


### PR DESCRIPTION
To fix the following exception introduced in the 2.0.23 release:
`verbb\formie\integrations\crm\MicrosoftDynamics365::getClient()`: Return value must be of type `verbb\formie\integrations\crm\Client`, `GuzzleHttp\Client` returned