### PR TITLE
Microsoft Dynamics 365: Fix for #1324 undefined array key

### DIFF
--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -508,8 +508,12 @@ class MicrosoftDynamics365 extends Crm
             // DateTime attributes, just because the AttributeType is DateTime doesn't mean it actually accepts one!
             // If a field DateTimeBehaviour is set to DateOnly, it will not accept DateTime values ever!
             // https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/behavior-format-date-time-attribute
-            if ($type === 'DateTime' && $dateTimeBehaviourValues[$metadataId] === 'DateOnly') {
-                $type = 'Date';
+            if ($type === 'DateTime') {
+                $dateTimeBehavior = $dateTimeBehaviourValues[$metadataId] ?? null;
+
+                if ($dateTimeBehavior === 'DateOnly') {
+                    $type = 'Date';
+                }
             }
 
             // Index by handle for easy lookup with PickLists


### PR DESCRIPTION
Following @alexjcollins issue report, it would appear the extra check for DateOnly DateTimeBehaviors can lead to a undefined array key. I'm not entirely sure how a field that's DateTime does not appear in the results of a query for DateTime fields on a entity, but to be defensive the lookup can use a null coalesce.

This may need further investigation as I thought using the metadataid was pretty solid, however it appears a field in the loop might not be present in the query for all DateTime fields on an entity, but I'd need to understand the specifics better, I can't replicate the issue on the Dynamics 365 environment we have, but like many CRM systems, no two are the same.

Temporarily, this patch should prevent a 500 error when refreshing the integration, if the lookup does not return anything.

