### PR TITLE
Add failsafe when using Date field with an empty Custom Date/Time as default

### DIFF
--- a/src/fields/formfields/Date.php
+++ b/src/fields/formfields/Date.php
@@ -144,6 +144,9 @@ class Date extends FormField implements SubfieldInterface, PreviewableFieldInter
 
                 if ($defaultValue) {
                     $this->defaultValue = $defaultValue;
+                } else {
+                    // If DateTime cast failed, fall back to empty default
+                    $this->defaultValue = null;
                 }
             } else {
                 $this->defaultValue = null;
@@ -1360,7 +1363,7 @@ class Date extends FormField implements SubfieldInterface, PreviewableFieldInter
     {
         $options = [['value' => '', 'label' => '', 'disabled' => true]];
 
-        for ($i = $start; $i <= $end; $i++) { 
+        for ($i = $start; $i <= $end; $i++) {
             $options[] = ['label' => $i, 'value' => $i];
         }
 


### PR DESCRIPTION
This patch prevents the error mentioned in #1344 when a Date field is saved with an empty **Default Date/Time** option.

I do feel like requiring a value for that input when "Custom Date/Time" is selected, would be a valuable UX improvement. However, since Formie overrides the default `date` FormKit component, seems like that would be a non-trivial task—one that I didn't quite feel confident tackling for a quick PR!