### PR TITLE
Microsoft Dynamics 365: Allow Web API version to be configurable via settings

### DIFF
--- a/docs/integrations/crm.md
+++ b/docs/integrations/crm.md
@@ -460,6 +460,11 @@ Follow the below steps to connect to the Microsoft Dynamics 365 API.
 1. Enable the integration and fill out all required fields.
 1. Click **Save** to save the form.
 
+### Optional: Microsoft Dynamics 365 Web API version
+
+The Microsoft Dynamics 365 Web API provides [different versions of the Web API](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/web-api-versions). This is to both maintain compatibility or implement new breaking changes. There are no major differences between v9.0, v9.1 or v9.2 currently. This setting allows you to specify a specific API version if required. When setting a specific value, all Microsoft Dynamics 365 Web API requests will use this API version in the request URI.
+
+For compatibility, the default setting is v9.0. This has been the value used in the Microsoft Dynamics 365 CRM integration prior to this being customisable.
 
 ## Pardot
 Follow the below steps to connect to the Pardot API.

--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -1,27 +1,19 @@
 <?php
 namespace verbb\formie\integrations\crm;
 
-use verbb\formie\events\MicrosoftDynamics365RequiredLevelsEvent;
-use verbb\formie\events\MicrosoftDynamics365TargetSchemasEvent;
-use verbb\formie\Formie;
-use verbb\formie\base\Crm;
-use verbb\formie\base\Integration;
-use verbb\formie\elements\Form;
-use verbb\formie\elements\Submission;
-use verbb\formie\errors\IntegrationException;
-use verbb\formie\events\SendIntegrationPayloadEvent;
-use verbb\formie\models\IntegrationCollection;
-use verbb\formie\models\IntegrationField;
-use verbb\formie\models\IntegrationFormSettings;
-
 use Craft;
 use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Json;
-use craft\helpers\StringHelper;
-use craft\web\View;
-
 use TheNetworg\OAuth2\Client\Provider\Azure;
+use verbb\formie\base\Crm;
+use verbb\formie\base\Integration;
+use verbb\formie\elements\Submission;
+use verbb\formie\events\MicrosoftDynamics365RequiredLevelsEvent;
+use verbb\formie\events\MicrosoftDynamics365TargetSchemasEvent;
+use verbb\formie\Formie;
+use verbb\formie\models\IntegrationField;
+use verbb\formie\models\IntegrationFormSettings;
 
 class MicrosoftDynamics365 extends Crm
 {
@@ -31,6 +23,7 @@ class MicrosoftDynamics365 extends Crm
     public $clientId;
     public $clientSecret;
     public $apiDomain;
+    public $apiVersion = 'v9.0';
     public $mapToContact = false;
     public $mapToLead = false;
     public $mapToOpportunity = false;
@@ -357,9 +350,10 @@ class MicrosoftDynamics365 extends Crm
 
         $token = $this->getToken();
         $url = rtrim(App::parseEnv($this->apiDomain), '/');
+        $apiVersion = $this->apiVersion;
 
         $this->_client = Craft::createGuzzleClient([
-            'base_uri' => "$url/api/data/v9.0/",
+            'base_uri' => "$url/api/data/$apiVersion/",
             'headers' => [
                 'Authorization' => 'Bearer ' . ($token->accessToken ?? 'empty'),
                 'Content-Type' => 'application/json',
@@ -381,7 +375,7 @@ class MicrosoftDynamics365 extends Crm
 
                 // Then try again, with the new access token
                 $this->_client = Craft::createGuzzleClient([
-                    'base_uri' => "$url/api/data/v9.0/",
+                    'base_uri' => "$url/api/data/$apiVersion/",
                     'headers' => [
                         'Authorization' => 'Bearer ' . ($token->accessToken ?? 'empty'),
                         'Content-Type' => 'application/json',

--- a/src/templates/integrations/crm/microsoft-dynamics-365/_plugin-settings.html
+++ b/src/templates/integrations/crm/microsoft-dynamics-365/_plugin-settings.html
@@ -42,6 +42,12 @@
 1. Save this integration.
 1. Click on the **Connect** button in the right-hand sidebar.
 1. You‘ll be redirected to {name}, where you must approve Formie to access your {name} account.
+
+### Optional: Microsoft Dynamics 365 Web API version
+
+The Microsoft Dynamics 365 Web API provides [different versions of the Web API](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/web-api-versions). This is to both maintain compatibility or implement new breaking changes. There are no major differences between v9.0, v9.1 or v9.2 currently. This setting allows you to specify a specific API version if required. When setting a specific value, all Microsoft Dynamics 365 Web API requests will use this API version in the request URI.
+
+For compatibility, the default setting is v9.0. This has been the value used in the Microsoft Dynamics 365 CRM integration prior to this being customisable.
 {% endset %}
 
 <div class="fui-settings-block">
@@ -92,4 +98,18 @@
     value: integration.settings.apiDomain ?? '',
     warning: macros.configWarning('apiDomain', 'formie'),
     errors: integration.getErrors('apiDomain'),
+}) }}
+
+{{ forms.selectField({
+    label: 'API version' | t('formie'),
+    instructions: 'Set a specific web API version to use with Microsoft Dynamics 365 Web API requests.' | t('formie'),
+    name: 'apiVersion',
+    options: [
+        { label: '9.0', value: 'v9.0'},
+        { label: '9.1', value: 'v9.1'},
+        { label: '9.2', value: 'v9.2'}
+    ],
+    value: integration.settings.apiVersion ?? 'v9.0',
+    warning: macros.configWarning('apiVersion', 'formie'),
+    errors: integration.getErrors('apiVersion'),
 }) }}

--- a/src/translations/en/formie.php
+++ b/src/translations/en/formie.php
@@ -942,6 +942,8 @@ return [
     'Choose how your form fields should map to your {name} Ticket fields.' => 'Choose how your form fields should map to your {name} Ticket fields.',
     'Domain' => 'Domain',
     'Enter your full {name} Domain here. e.g. `https://example.freshdesk.com`' => 'Enter your full {name} Domain here. e.g. `https://example.freshdesk.com`',
+    'API version' => 'API version',
+    'Set a specific web API version to use with Microsoft Dynamics 365 Web API requests.' => 'Set a specific web API version to use with Microsoft Dynamics 365 Web API requests.',
     'Map to Opportunity' => 'Map to Opportunity',
     'Whether to map form data to {name} Opportunitys.' => 'Whether to map form data to {name} Opportunitys.',
     'Opportunity Field Mapping' => 'Opportunity Field Mapping',


### PR DESCRIPTION
Related to #1350.

This creates a integration plugin setting for the Dynamics 365 CRM integration to allow the selection of the Web API version. The options supported are v9.0, v9.1 and v9.2. By default v9.0 is used to maintain compatibility with any existing Microsoft Dynamics 365 integration before the setting has been made available.