### PR TITLE
Microsoft Dynamics 365: For checking the validity of a token use the WhoAmI endpoint

### DIFF
--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -1,27 +1,19 @@
 <?php
 namespace verbb\formie\integrations\crm;
 
-use verbb\formie\events\MicrosoftDynamics365RequiredLevelsEvent;
-use verbb\formie\events\MicrosoftDynamics365TargetSchemasEvent;
-use verbb\formie\Formie;
-use verbb\formie\base\Crm;
-use verbb\formie\base\Integration;
-use verbb\formie\elements\Form;
-use verbb\formie\elements\Submission;
-use verbb\formie\errors\IntegrationException;
-use verbb\formie\events\SendIntegrationPayloadEvent;
-use verbb\formie\models\IntegrationCollection;
-use verbb\formie\models\IntegrationField;
-use verbb\formie\models\IntegrationFormSettings;
-
 use Craft;
 use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Json;
-use craft\helpers\StringHelper;
-use craft\web\View;
-
 use TheNetworg\OAuth2\Client\Provider\Azure;
+use verbb\formie\base\Crm;
+use verbb\formie\base\Integration;
+use verbb\formie\elements\Submission;
+use verbb\formie\events\MicrosoftDynamics365RequiredLevelsEvent;
+use verbb\formie\events\MicrosoftDynamics365TargetSchemasEvent;
+use verbb\formie\Formie;
+use verbb\formie\models\IntegrationField;
+use verbb\formie\models\IntegrationFormSettings;
 
 class MicrosoftDynamics365 extends Crm
 {
@@ -369,11 +361,7 @@ class MicrosoftDynamics365 extends Crm
         // Always provide an authenticated client - so check first.
         // We can't always rely on the EOL of the token.
         try {
-            $response = $this->request('GET', 'contacts', [
-                'query' => [
-                    '$top' => '1',
-                ],
-            ]);
+            $this->request('GET', 'WhoAmI');
         } catch (\Throwable $e) {
             if ($e->getCode() === 401) {
                 // Force-refresh the token


### PR DESCRIPTION
In order to check the validity of a token, the endpoint used to test can be optimised to use the [WhoAmI endpoint](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/whoami?view=dataverse-latest). This is much less resource intensive than pulling a full contact record in the current logic without any select criteria. The WhoAmI endpoint returns similar to the following on success:

```json
{
    "@odata.context": "https://example.crm11.dynamics.com/api/data/v9.0/$metadata#Microsoft.Dynamics.CRM.WhoAmIResponse",
    "BusinessUnitId": "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
    "UserId": "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
    "OrganizationId": "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx"
}
```

Otherwise if unauthenticated a 401 response will be returned, this should be a drop in replacement but likely improve the response time on this check.

Having the request in the `$response` variable is not required, given the catch logic is specifically looking for a 401 response code using `$e`.

