### PR TITLE
Fix CVE-2022-41343, CVE-2023-23924, CVE-2023-24813

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^8.0.2",
         "commerceguys/addressing": "^1.2",
         "craftcms/cms": "^4.3.2",
-        "dompdf/dompdf": "^1.0.2 || ^2.0.0",
+        "dompdf/dompdf": "^1.0.2 || ^2.0.3",
         "ezyang/htmlpurifier": "^4.13",
         "fakerphp/faker": "^1.9.1",
         "giggsey/libphonenumber-for-php": "^8.12",


### PR DESCRIPTION
Require `dompdf/dompdf` version `2.0.3+` to fix following vulnerabilities:
* CVE-2022-41343
* CVE-2023-23924
* CVE-2023-24813