### PR TITLE
ActiveCampaign: Get all tags with pagination

### DIFF
--- a/src/integrations/crm/ActiveCampaign.php
+++ b/src/integrations/crm/ActiveCampaign.php
@@ -323,8 +323,7 @@ class ActiveCampaign extends Crm
 
                     if ($tags) {
                         // Find all the tags first
-                        $response = $this->request('GET', 'tags');
-                        $existingTags = $response['tags'] ?? [];
+                        $existingTags = $this->_getPaginated('tags');
                         $tagIds = [];
 
                         // Process each tag

--- a/src/integrations/emailmarketing/ActiveCampaign.php
+++ b/src/integrations/emailmarketing/ActiveCampaign.php
@@ -167,8 +167,7 @@ class ActiveCampaign extends EmailMarketing
 
                 if ($tags) {
                     // Find all the tags first
-                    $response = $this->request('GET', 'tags');
-                    $existingTags = $response['tags'] ?? [];
+                    $existingTags = $this->_getPaginated('tags');
                     $tagIds = [];
 
                     // Process each tag


### PR DESCRIPTION
By default you only get the first 20 tags. This fix add pagination to get all tags from ActiveCampaign.