### PR TITLE
ActiveCampaign: Apply _getPaginated to Tags

### DIFF
--- a/src/integrations/crm/ActiveCampaign.php
+++ b/src/integrations/crm/ActiveCampaign.php
@@ -322,8 +322,7 @@ class ActiveCampaign extends Crm
 
                     if ($tags) {
                         // Find all the tags first
-                        $response = $this->request('GET', 'tags');
-                        $existingTags = $response['tags'] ?? [];
+                        $existingTags = $this->_getPaginated('tags');
                         $tagIds = [];
 
                         // Process each tag

--- a/src/integrations/emailmarketing/ActiveCampaign.php
+++ b/src/integrations/emailmarketing/ActiveCampaign.php
@@ -173,8 +173,7 @@ class ActiveCampaign extends EmailMarketing
 
                 if ($tags) {
                     // Find all the tags first
-                    $response = $this->request('GET', 'tags');
-                    $existingTags = $response['tags'] ?? [];
+                    $existingTags = $this->_getPaginated('tags');
                     $tagIds = [];
 
                     // Process each tag


### PR DESCRIPTION
Fix to also paginate tags for ActiveCampaign on Formie 1.6 (Craft 3). 