### PR TITLE
Fixed bug when sending value of multiple checkboxes in hubspot

### DIFF
--- a/src/integrations/crm/HubSpot.php
+++ b/src/integrations/crm/HubSpot.php
@@ -340,10 +340,21 @@ class HubSpot extends Crm
                         continue;
                     }
 
-                    $formPayload['fields'][] = [
-                        'name' => $key,
-                        'value' => $value,
-                    ];
+                    // If multiple checkboxes option is chosen, map the value to seperate [name, value] options
+                    // instead of returning the value as an array
+                    if (is_array($value)) {
+                        foreach ($value as $item) {
+                            $formPayload['fields'][] = [
+                                'name' => $key,
+                                'value' => $item,
+                            ];
+                        }
+                    } else {
+                        $formPayload['fields'][] = [
+                            'name' => $key,
+                            'value' => $value,
+                        ];
+                    }
                 }
 
                 // Setup Hubspot's context


### PR DESCRIPTION
Hi,

I added a fix to make it possible to post the checkbox from Hubspot. There was a problem where it would send an array with the value instead of every value separately:
![image](https://github.com/verbb/formie/assets/5928907/4a6fc54b-51fc-4e3c-92c2-1fcf2e4e42da)


![Screenshot 2023-06-15 at 14 27 25](https://github.com/verbb/formie/assets/5928907/b9aa04fe-c158-44d2-894d-298e4ebfa1ac)

Correct way: 
![Screenshot 2023-06-15 at 14 28 26](https://github.com/verbb/formie/assets/5928907/39ddcb64-84c1-4ce1-a4b4-2e86ddc51c56)

