### PR TITLE
Custom template path validation

### DIFF
--- a/src/models/BaseTemplate.php
+++ b/src/models/BaseTemplate.php
@@ -88,18 +88,21 @@ abstract class BaseTemplate extends Model
                 $oldTemplatesPath = $view->getTemplatesPath();
                 $view->setTemplatesPath($templatesPath);
 
-                // Check how to validate templates
-                if ($this->hasSingleTemplate) {
-                    if (!$view->doesTemplateExist($this->$attribute)) {
+                // Check if we need to validate templates. Allow power users to handle form template path checks on their own
+                if (Formie::getInstance()->getSettings()->validateCustomTemplates) {
+                    // Check how to validate templates
+                    if ($this->hasSingleTemplate) {
+                        if (!$view->doesTemplateExist($this->$attribute)) {
+                            // Check for the template across multiple base paths
+                            if (!FileHelper::doesSitePathExist($this->$attribute)) {
+                                $validator->addError($this, $attribute, Craft::t('formie', 'The template does not exist.'));
+                            }
+                        }
+                    } else {
                         // Check for the template across multiple base paths
                         if (!FileHelper::doesSitePathExist($this->$attribute)) {
-                            $validator->addError($this, $attribute, Craft::t('formie', 'The template does not exist.'));
+                            $validator->addError($this, $attribute, Craft::t('formie', 'The template directory does not exist.'));
                         }
-                    }
-                } else {
-                    // Check for the template across multiple base paths
-                    if (!FileHelper::doesSitePathExist($this->$attribute)) {
-                        $validator->addError($this, $attribute, Craft::t('formie', 'The template directory does not exist.'));
                     }
                 }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -28,6 +28,7 @@ class Settings extends Model
     public string $defaultPage = 'forms';
 
     // Forms
+    public bool $validateCustomTemplates = true; // Allow power users to handle form template path checks on their own
     public string $defaultFormTemplate = '';
     public string $defaultEmailTemplate = '';
     public bool $enableUnloadWarning = true;


### PR DESCRIPTION
This PR would allow users to handle template root validation on their own. The default formie check only allows for custom forms to be located in the project templates directory, this would allow for them to be located in any custom template namespace.

This PR doesn't provide any kind of UI to modify this setting, so initially it is only intended to be modifiable via `config/formie.php` configuration file.