### PR TITLE
[Formie -> forms] add custom status field to form and allow for filtering in backend

### DIFF
--- a/src/elements/actions/SetFormStatus.php
+++ b/src/elements/actions/SetFormStatus.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace verbb\formie\elements\actions;
+
+use verbb\formie\Formie;
+
+use Craft;
+use craft\elements\actions\SetStatus;
+use craft\elements\db\ElementQueryInterface;
+use craft\helpers\Json;
+use verbb\formie\elements\Form;
+
+class SetFormStatus extends SetStatus
+{
+    // Properties
+    // =========================================================================
+
+    public ?string $formStatus = null;
+    public array $statuses = [];
+
+
+    // Public Methods
+    // =========================================================================
+
+    public function getTriggerLabel(): string
+    {
+        return Craft::t('app', 'Set Status');
+    }
+
+    public function getTriggerHtml(): ?string
+    {
+        return Craft::$app->getView()->renderTemplate('formie/_components/actions/form-set-status/trigger', [
+            'statuses' => $this->statuses,
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function performAction(ElementQueryInterface $query): bool
+    {
+        $elementsService = Craft::$app->getElements();
+
+        $elements = $query->all();
+        $failCount = 0;
+
+        /** @var Form $element */
+        foreach ($elements as $element) {
+            if ($element) {
+                $element->setFormStatus($this->formStatus);
+
+                if ($elementsService->saveElement($element) === false) {
+                    Formie::error('Unable to set status: {error}', ['error' => Json::encode($element->getErrors())]);
+
+                    // Validation error
+                    $failCount++;
+                }
+            }
+        }
+
+        // Did all of them fail?
+        if ($failCount === count($elements)) {
+            if (count($elements) === 1) {
+                $this->setMessage(Craft::t('app', 'Could not update status due to a validation error.'));
+            } else {
+                $this->setMessage(Craft::t('app', 'Could not update statuses due to validation errors.'));
+            }
+
+            return false;
+        }
+
+        if ($failCount !== 0) {
+            $this->setMessage(Craft::t('app', 'Status updated, with some failures due to validation errors.'));
+        } else if (count($elements) === 1) {
+            $this->setMessage(Craft::t('app', 'Status updated.'));
+        } else {
+            $this->setMessage(Craft::t('app', 'Statuses updated.'));
+        }
+
+        return true;
+    }
+
+
+    // Protected Methods
+    // =========================================================================
+
+    protected function defineRules(): array
+    {
+        // Don't include the parent rules from `SetStatus`
+        $rules = [];
+
+        $rules[] = [['formStatus'], 'required'];
+        $rules[] = [['formStatus'], 'in', 'range' => $this->statuses];
+
+        return $rules;
+    }
+}

--- a/src/elements/db/FormQuery.php
+++ b/src/elements/db/FormQuery.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace verbb\formie\elements\db;
 
 use verbb\formie\models\FormTemplate;
-
+use verbb\formie\elements\Form;
 use craft\db\Query;
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
@@ -14,6 +15,7 @@ class FormQuery extends ElementQuery
 
     public mixed $handle = null;
     public mixed $templateId = null;
+    public mixed $formStatus = null;
 
     protected array $defaultOrderBy = ['elements.dateCreated' => SORT_DESC];
 
@@ -50,6 +52,23 @@ class FormQuery extends ElementQuery
         return $this;
     }
 
+    public function status(array|string|null $value): static
+    {
+        $this->formStatus = $value;
+
+        return $this;
+    }
+
+
+    protected function statusCondition(string $status): mixed
+    {
+        if (in_array($status, FORM::STATUSES, true)) {
+            return ['formie_forms.formStatus' => $status];
+        }
+
+        return [];
+    }
+
 
     // Protected Methods
     // =========================================================================
@@ -60,6 +79,7 @@ class FormQuery extends ElementQuery
 
         $this->query->select([
             'formie_forms.id',
+            'formie_forms.formStatus',
             'formie_forms.handle',
             'formie_forms.fieldContentTable',
             'formie_forms.settings',
@@ -81,6 +101,10 @@ class FormQuery extends ElementQuery
 
         if ($this->templateId) {
             $this->subQuery->andWhere(Db::parseParam('formie_forms.templateId', $this->templateId));
+        }
+
+        if ($this->formStatus) {
+            $this->subQuery->andWhere(Db::parseParam('formie_forms.formStatus', $this->formStatus));
         }
 
         return parent::beforePrepare();

--- a/src/migrations/m230716_000000_add_status_to_form.php
+++ b/src/migrations/m230716_000000_add_status_to_form.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace verbb\formie\migrations;
+
+use craft\db\Migration;
+use verbb\formie\elements\Form;
+
+class m230716_000000_add_status_to_form extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        if (!$this->db->columnExists('{{%formie_forms}}', 'formStatus')) {
+            $this->addColumn('{{%formie_forms}}', 'formStatus', $this->string());
+            $this->update('{{%formie_forms}}', ['formStatus' => Form::STATUS_ACTIVE]);
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        if ($this->db->columnExists('{{%formie_forms}}', 'formStatus')) {
+            $this->dropColumn('{{%formie_forms}}', 'formStatus');
+        }
+
+        return true;
+    }
+}

--- a/src/services/Forms.php
+++ b/src/services/Forms.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace verbb\formie\services;
 
 use verbb\formie\Formie;
@@ -214,7 +215,7 @@ class Forms extends Component
                 foreach ($captchas as $captcha) {
                     // Check to see if we have any data already applied from a stencil
                     $integrationEnabled = $form->settings->integrations[$captcha->handle]['enabled'] ?? null;
-                    
+
                     if ($captcha->getEnabled() && $integrationEnabled === null) {
                         $form->settings->integrations[$captcha->handle]['enabled'] = true;
                     }
@@ -261,7 +262,7 @@ class Forms extends Component
             $transaction->rollBack();
 
             $form->addErrors(['general' => $e->getMessage()]);
-            
+
             Formie::error('Unable to save form “' . $form->handle . '”: ' . $e->getMessage());
 
             return false;
@@ -380,6 +381,7 @@ class Forms extends Component
         $request = Craft::$app->getRequest();
         $formId = $request->getParam('formId');
         $siteId = $request->getParam('siteId');
+        $status = $request->getParam('status');
         $duplicate = (bool)$request->getParam('duplicate');
 
         if ($formId) {
@@ -406,6 +408,7 @@ class Forms extends Component
         }
 
         $form->siteId = $siteId ?? $form->siteId;
+        $form->setFormStatus($status ?? $form->getFormStatus());
         $form->handle = $request->getParam('handle', $form->handle);
         $form->templateId = \verbb\formie\helpers\StringHelper::toId($request->getParam('templateId', $form->templateId));
         $form->defaultStatusId = \verbb\formie\helpers\StringHelper::toId($request->getParam('defaultStatusId', $form->defaultStatusId));

--- a/src/templates/_components/actions/form-set-status/trigger.html
+++ b/src/templates/_components/actions/form-set-status/trigger.html
@@ -1,0 +1,9 @@
+<div class="btn menubtn">{{ 'Set status' | t('app') }}</div>
+<div class="menu">
+    <ul>
+        {% for status in statuses %}
+            {% set color = status == 'active' ? 'green' : 'white' %}
+        <li><a class="formsubmit" data-param="formStatus" data-value="{{ status }}"><span class="status {{ color }}"></span> {{ status }}</a></li>
+        {% endfor %}
+    </ul>
+</div>

--- a/src/templates/forms/_panes/settings.html
+++ b/src/templates/forms/_panes/settings.html
@@ -17,6 +17,27 @@
 
 <hr>
 
+{{ forms.selectField({
+    label: 'Status' | t('formie'),
+    instructions: 'What is the current status of this form' | t('formie'),
+    id: 'status',
+    name: 'status',
+    required: true,
+    options: [
+        {
+            label: 'Active' | t('formie'),
+            value: 'active',
+        },
+        {
+            label: 'Inactive' | t('formie'),
+            value: 'inactive',
+        },
+    ],
+    value: form.getFormStatus(),
+}) }}
+
+<hr>
+
 <h2>{{ 'Submissions' | t('formie') }}</h2>
 
 {{ forms.hidden({


### PR DESCRIPTION
Hiya, 

This PR is in relation to issue #1471 

I implemented the simplest way I could think off in my short craft experience to add some very basic statuses on Form level. I would be more than happy to work on this a lot more to rewrite this in a more solid way. 

 This way we can at least offer our clients the option to manage their forms a bit more conveniently when they have a large amount of outdated forms that they do not want to delete for administrative reasons. 
 
 Numkil