### PR TITLE
[Submissions] Bug cannot edit submission when form has reached submission limit

### DIFF
--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -437,7 +437,7 @@ class Submission extends Element
             }
         }
 
-        if ($form && $form->settings->limitSubmissions) {
+        if ($this->isIncomplete && $form && $form->settings->limitSubmissions) {
             if (!$form->isWithinSubmissionsLimit()) {
                 $this->addError('form', Craft::t('formie', 'This form has met the number of allowed submissions.'));
             }


### PR DESCRIPTION
Hi All,

I found a bug where you can no longer edit any of the submissions from a Form that has reached its submission limit. This is because the Validate function does not check whether a submission is being newly added or an existing submission is being edited.

By checking if the ID is set on the submission element we can know wether a submission is brand new or not. 

Numkil 