### PR TITLE
Add a flag to getRequestParam to distinguish empty string from null

### DIFF
--- a/src/base/Captcha.php
+++ b/src/base/Captcha.php
@@ -123,11 +123,13 @@ abstract class Captcha extends Integration
         return $value;
     }
 
-    protected function getRequestParam($name)
+    protected function getRequestParam($name, $allowEmptyString = false)
     {
         // Handle the traditional param, as a POST param
         if ($param = Craft::$app->getRequest()->getParam($name)) {
-            return $param;
+            if ($allowEmptyString || $param) {
+                return $param;
+            }
         }
 
         // Handle the param being set in a GQL mutation
@@ -135,7 +137,9 @@ abstract class Captcha extends Integration
             $paramName = $param['name'] ?? null;
 
             if ($paramName === $name) {
-                return $param['value'] ?? null;
+                if ($allowEmptyString || $param) {
+                    return $param['value'] ?? null;
+                }
             }
         }
 

--- a/src/integrations/captchas/Honeypot.php
+++ b/src/integrations/captchas/Honeypot.php
@@ -63,8 +63,7 @@ class Honeypot extends Captcha
         }
 
         // If the honeypot param has been stripped out of the request altogether
-        // Don't use `getRequestParam()` as we want to check for strict `null`
-        if ($this->getRequestParam(self::HONEYPOT_INPUT_NAME) === null) {
+        if ($this->getRequestParam(self::HONEYPOT_INPUT_NAME, true) === null) {
             $this->spamReason = Craft::t('formie', 'Honeypot param missing: {v}.', ['v' => self::HONEYPOT_INPUT_NAME]);
 
             return false;


### PR DESCRIPTION
Add a flag to getRequestParam to distinguish empty string from null, and use it during one of the honeypot checks.

Without this, empty string is being returned as null, and so GQL submissions with honeypot are always being marked as spam.

See #1511