### PR TITLE
Craft 3: Backport of fix some characters (quotes) being encoded for field values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "league/oauth2-google": "^3.0",
         "thenetworg/oauth2-azure": "^2.0",
         "dompdf/dompdf": "^1.0.2 || ^2.0.0",
-        "verbb/base": "^1.0.0"
+        "verbb/base": "^1.0.0",
+        "voku/anti-xss": "^4.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/base/FormFieldTrait.php
+++ b/src/base/FormFieldTrait.php
@@ -13,6 +13,7 @@ use verbb\formie\fields\formfields\BaseOptionsField;
 use verbb\formie\fields\formfields\Hidden;
 use verbb\formie\helpers\ConditionsHelper;
 use verbb\formie\helpers\SchemaHelper;
+use verbb\formie\helpers\StringHelper;
 use verbb\formie\helpers\Variables;
 use verbb\formie\gql\types\generators\FieldAttributeGenerator;
 use verbb\formie\gql\types\generators\KeyValueGenerator;
@@ -27,7 +28,6 @@ use craft\helpers\DateTimeHelper;
 use craft\helpers\Html;
 use craft\helpers\Json;
 use craft\helpers\Template;
-use craft\helpers\StringHelper;
 use craft\validators\HandleValidator;
 use craft\web\twig\TemplateLoaderException;
 
@@ -1213,7 +1213,7 @@ trait FormFieldTrait
     protected function defineValueAsString($value, ElementInterface $element = null)
     {
         // Escape any HTML in field content for good measure
-        return StringHelper::escape((string)$value);
+        return StringHelper::cleanString((string)$value);
     }
 
     /**

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -1,0 +1,14 @@
+<?php
+namespace verbb\formie\helpers;
+
+use craft\helpers\StringHelper as CraftStringHelper;
+
+use voku\helper\AntiXSS;
+
+class StringHelper extends CraftStringHelper
+{
+    public static function cleanString(string $str): string
+    {
+        return (new AntiXSS())->xss_clean($str);
+    }
+}


### PR DESCRIPTION
This is a backport of the fix for certain entities being converted in email notifications/payloads.

This is usually triggered by name data such as `Example O'Something`, or apostrophe usage in values.

(cherry picked from commit 49ab9d748d9dcb0c5d9f7e5637f918545a3d42f0)