### PR TITLE
Craft 3: Map an account to lead data using parentaccountid or customerid_account

### DIFF
--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -258,8 +258,17 @@ class MicrosoftDynamics365 extends Crm
                 $leadPayload = $leadValues;
 
                 if ($contactId) {
-                    $leadPayload['parentcontactid@odata.bind'] = $this->_formatLookupValue('contacts', $contactId);
-                    $leadPayload['customerid_contact@odata.bind'] = $this->_formatLookupValue('contacts', $contactId);
+                    $contactLookupValue = $this->_formatLookupValue('contacts', $contactId);
+
+                    $leadPayload['parentcontactid@odata.bind'] = $contactLookupValue;
+                    $leadPayload['customerid_contact@odata.bind'] = $contactLookupValue;
+                }
+
+                if ($accountId) {
+                    $accountLookupValue = $this->_formatLookupValue('accounts', $accountId);
+
+                    $leadPayload['parentaccountid@odata.bind'] = $accountLookupValue;
+                    $leadPayload['customerid_account@odata.bind'] = $accountLookupValue;
                 }
 
                 $response = $this->deliverPayload($submission, 'leads?$select=leadid', $leadPayload);


### PR DESCRIPTION
Account entities can be linked to lead data via the standard parentaccountid/customerid_account fields.

Depending on certain CRM customisations, either one may be used.

A lightswitch on the mapping could be implemented to only include these in the payload if wanted i.e. choosing which one, but these are standard Dynamics 365 fields so it shouldn't cause a problem.