### PR TITLE
fix: Update BaseTemplate.php with Formie reference

### DIFF
--- a/src/models/BaseTemplate.php
+++ b/src/models/BaseTemplate.php
@@ -1,6 +1,7 @@
 <?php
 namespace verbb\formie\models;
 
+use verbb\formie\Formie;
 use verbb\formie\helpers\FileHelper;
 
 use Craft;


### PR DESCRIPTION
Missing reference for Formie used on line 92 (or 93 now):
```
if (Formie::$plugin->getSettings()->validateCustomTemplates) {
  ...
}
```

<img width="1728" alt="Screenshot 2023-09-01 at 10 09 01" src="https://github.com/verbb/formie/assets/6649706/b7ecd9f9-27e4-4aaa-b2b0-96ee21c7d8fc">

Occurred when adding a form template with the "Use Custom Template" toggled on.