### PR TITLE
Microsoft Dynamics 365 CRM: Add expand parameter to EVENT_MODIFY_TARGET_SCHEMAS

### DIFF
--- a/docs/developers/events.md
+++ b/docs/developers/events.md
@@ -1794,8 +1794,9 @@ Any modifications made to the standard entities such as `systemuser` or `campaig
 
 The following additional parameters are available for each entity:
 
-* `limit` - Set the amount of values to return (defaults to 100 if not specifically set)
+* `expand` - For more complex queries related to one or more entities
 * `filter` - Specify a filter to modify the returned values
+* `limit` - Set the amount of values to return (defaults to 100 if not specifically set)
 * `orderby` - Order the returned values by a specific criteria e.g. `name asc`
 
 When using the `limit` option. Be mindful of the performance impact when refreshing the integration.

--- a/src/integrations/crm/MicrosoftDynamics365.php
+++ b/src/integrations/crm/MicrosoftDynamics365.php
@@ -746,10 +746,11 @@ class MicrosoftDynamics365 extends Crm
                 // Fetch the entities and use the schema options to store. Be sure to limit and be performant.
                 $response = $this->request('GET', $targetSchema['entity'], [
                     'query' => [
-                        '$top' => $targetSchema['limit'] ?? '100',
-                        '$select' => implode(',', $select),
+                        '$expand' => $targetSchema['expand'] ?? null,
+                        '$filter' => $targetSchema['filter'] ?? null,
                         '$orderby' => $targetSchema['orderby'] ?? null,
-                        '$filter' => $targetSchema['filter'] ?? null
+                        '$select' => implode(',', $select),
+                        '$top' => $targetSchema['limit'] ?? '100'
                     ],
                 ]);
 


### PR DESCRIPTION
This adds support for using the expand parameter for certain target schemas, mainly for more advanced queries if required.