### PR TITLE
Dotdigital: Add email campaign and email campaign send date fields to mapping

### DIFF
--- a/src/templates/integrations/crm/dotdigital/_form-settings.html
+++ b/src/templates/integrations/crm/dotdigital/_form-settings.html
@@ -3,6 +3,7 @@
 {% set handle = integration.handle %}
 {% set formSettings = integration.getFormSettings().getSettings() %}
 {% set mapToContact = form.settings.integrations[handle].mapToContact ?? '' %}
+{% set sendEmailCampaign = form.settings.integrations[handle].sendEmailCampaign ?? '' %}
 
 <field-select
     label="{{ 'Opt-In Field' | t('formie') }}"
@@ -47,6 +48,33 @@
 
             <ul v-if="!isEmpty(get(form, 'settings.integrations.{{ handle }}.errors.contactFieldMapping'))" class="errors" v-cloak>
                 <li v-for="(error, index) in get(form, 'settings.integrations.{{ handle }}.errors.contactFieldMapping')" :key="index">
+                    ${ error }
+                </li>
+            </ul>
+        </div>
+
+        {{ forms.lightswitchField({
+            label: 'Send email campaign' | t('formie'),
+            instructions: 'Whether to send an email campaign to a contact' | t('formie', { name: integration.displayName() }),
+            id: 'sendEmailCampaign',
+            name: 'sendEmailCampaign',
+            on: sendEmailCampaign,
+            toggle: 'send-email-campaign',
+        }) }}
+
+        <div id="send-email-campaign" class="{{ not sendEmailCampaign or not mapToContact ? 'hidden' }}">
+            <integration-field-mapping
+                    label="{{ 'Email Campaign Mapping' | t('formie') }}"
+                    instructions="{{ 'Choose an email campaign to send to a contact. Optionally you can set the send date to be in the future.' | t('formie', { name: integration.displayName() }) }}"
+                    name-label="{{ integration.displayName() }}"
+                    id="email-send-mapping"
+                    name="emailSendMapping"
+                    :value="get(form, 'settings.integrations.{{ handle }}.emailSendMapping')"
+                    :rows="get(settings, 'emailCampaign')"
+            ></integration-field-mapping>
+
+            <ul v-if="!isEmpty(get(form, 'settings.integrations.{{ handle }}.errors.emailSendMapping'))" class="errors" v-cloak>
+                <li v-for="(error, index) in get(form, 'settings.integrations.{{ handle }}.errors.emailSendMapping')" :key="index">
                     ${ error }
                 </li>
             </ul>


### PR DESCRIPTION
This adds support to the Dotdigital integration to automatically send a campaign upon creating a contact by mapping to an email campaign. In addition you can also specify a send date which would likely be either a string of a iso8601 date or a date/time object formatted.

* Add an email campaign and email send date mapping option and setting
* Pulls in email campaigns under a dotdigital account
* Predefined options for send date in the future (also supports a datetime object)

#1582

