### PR TITLE
Add user impersonation feature to Microsoft Dynamics 365 integration

### DIFF
--- a/docs/integrations/crm.md
+++ b/docs/integrations/crm.md
@@ -476,11 +476,31 @@ Ensure you have Azure administrator access or an Azure administrator is able to 
 1. Enable the integration and fill out all required fields.
 1. Click **Save** to save the form.
 
-### Optional: Microsoft Dynamics 365 Web API version
+### Optional: Web API version
 
 The Microsoft Dynamics 365 Web API provides [different versions of the Web API](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/web-api-versions). This is to both maintain compatibility or implement new breaking changes. There are no major differences between v9.0, v9.1 or v9.2 currently. This setting allows you to specify a specific API version if required. When setting a specific value, all Microsoft Dynamics 365 Web API requests will use this API version in the request URI.
 
 For compatibility, the default setting is v9.0. This has been the value used in the Microsoft Dynamics 365 CRM integration prior to this being customisable.
+
+### Optional: Impersonate user
+
+When CRM records are created through Formie the user context of the account used to authenticate the OAuth connection is used (this is different to the application user). Depending on requirements, you may wish to override this. The easiest option is to authenticate under the account you wish to have records created by as, however this may not always be possible.
+
+Using <a href="https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/impersonate-another-user-web-api#how-to-impersonate-a-user" target="_blank">user impersonation</a> you can set another systemuser context instead without changing the OAuth connection.
+
+**Impersonation settings:**
+
+* Impersonate user - Toggle the entire feature on or off.
+* Impersonate header - This sets the HTTP header to either `CallerObjectId` or `MSCRMCallerID`. Depending on your environment one or the other will need to be used relative to the user ID provided.
+* Impersonate User ID - This is the GUID of a valid systemuser within your Microsoft Dynamics 365 CRM.
+
+When enabled this will be applied to all Microsoft Dynamics 365 CRM enabled forms.
+
+By setting the impersonate HTTP header, this will also populate the Created By (delegate) field to the actual user context to provide a more accurate audit trail.
+
+If you want to selectively control the "Created" By value on records per form, use the Created By field in the mapping.
+
+**Note:** The impersonate user feature is set via a HTTP header on POST requests which will override any Created By field mapping that is set.
 
 ## Pardot
 Follow the below steps to connect to the Pardot API.

--- a/src/templates/integrations/crm/microsoft-dynamics-365/_plugin-settings.html
+++ b/src/templates/integrations/crm/microsoft-dynamics-365/_plugin-settings.html
@@ -118,3 +118,48 @@ For compatibility, the default setting is v9.0. This has been the value used in 
     warning: macros.configWarning('apiVersion', 'formie'),
     errors: integration.getErrors('apiVersion'),
 }) }}
+
+{% set impersonationInstructions %}
+### Impersonation user settings
+
+By default all records created will appear as the authenticated user which the OAuth token was requested under (This differs from the application user). If you would like to modify this, <a href="https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/impersonate-another-user-web-api#how-to-impersonate-a-user" target="_blank">you can use impersonation</a>. This will apply to all Microsoft Dynamics 365 forms with the integration enabled.
+
+**Note:** Impersonation may require additional security permissions not covered in the setup instructions.
+
+If you want to selectively control the created by user per form, use the "Created By" field in the mapping instead.
+{% endset %}
+
+<div class="fui-settings-block">
+    {{ impersonationInstructions | t('formie') | md }}
+</div>
+
+{{ forms.lightswitchField({
+    label: 'Impersonate user' | t('formie'),
+    instructions: 'Enable this setting to impersonate the user for created records to be set as.' | t('formie'),
+    id: 'impersonateUser',
+    name: 'impersonateUser',
+    on: integration.settings.impersonateUser ?? false
+}) }}
+
+{{ forms.selectField({
+    label: 'Impersonation header' | t('formie'),
+    instructions: 'Set the value of the impersonate header to be used.' | t('formie'),
+    name: 'impersonateHeader',
+    options: [
+        { label: 'CallerObjectId', value: 'CallerObjectId' },
+        { label: 'MSCRMCallerID', value: 'MSCRMCallerID' }
+    ],
+    value: integration.settings.impersonateHeader ?? 'CallerObjectId',
+    warning: macros.configWarning('impersonateHeader', 'formie'),
+    errors: integration.getErrors('impersonateHeader')
+}) }}
+
+{{ forms.autosuggestField({
+    label: 'Impersonate User ID' | t('formie'),
+    instructions: 'Enter the GUID of a valid systemuser to impersonate.' | t('formie'),
+    name: 'impersonateUserId',
+    suggestEnvVars: true,
+    value: integration.settings.impersonateUserId ?? '',
+    warning: macros.configWarning('impersonateUserId', 'formie'),
+    errors: integration.getErrors('impersonateUserId')
+}) }}


### PR DESCRIPTION
This implements the impersonate user feature available through a specific HTTP header, as discussed in #1567.

It add three additional settings:

1. A lightswitch to turn the feature on or off entirely.
2. Two options for the HTTP header to use, this differs depending on the user ID used and the environment.
3. A User ID field to store a GUID of a systemuser

The model validates the User ID being required only when the feature is enabled, as a User ID is required as the header value. The value does not need to be modifed with the systemusers entity e.g. `systemusers(GUID)`.

I have added a docs note, this would be an advanced feature but potentially useful as an extension to the recent Created By field mapping update.

