### PR TITLE
Hide PayPal payment field after successful payment

### DIFF
--- a/src/web/assets/frontend/src/js/payments/paypal.js
+++ b/src/web/assets/frontend/src/js/payments/paypal.js
@@ -192,6 +192,8 @@ export class FormiePayPal extends FormiePaymentProvider {
                             this.addError(t('Missing Authorization ID for approval.'));
                         } else {
                             this.addSuccess(t('Payment authorized. Finalize the form to complete payment.'));
+                            // Remove the button so it's not rendered after successful payment
+                            this.$input.innerHTML = '';
                         }
                     } catch (error) {
                         console.error(error);


### PR DESCRIPTION
It is confusing when a payment is successful because the buttons still display after the payment. Adding a line to remove the payment field if it is successful.