### PR TITLE
Update Rich Text editor to support placeholder attribute

### DIFF
--- a/src/templates/_formfields/multi-line-text/input.html
+++ b/src/templates/_formfields/multi-line-text/input.html
@@ -5,7 +5,7 @@
 
 {% block field %}
     {% if field.useRichText %}
-        <div class="fui-rich-text" data-rich-text></div>
+        <div class="fui-rich-text" data-rich-text {% if field.placeholder %} data-placeholder="{{ field.placeholder}}" {% endif %}></div>
 
         <div style="display: none !important;">
             {% include '_includes/forms/textarea' with { rows: 5 } %}

--- a/src/web/assets/frontend/src/js/fields/rich-text.js
+++ b/src/web/assets/frontend/src/js/fields/rich-text.js
@@ -7,6 +7,7 @@ export class FormieRichText {
         this.$field = settings.$field.querySelector('textarea');
         this.$container = settings.$field.querySelector('[data-rich-text]');
         this.scriptId = 'FORMIE_FONT_AWESOME_SCRIPT';
+        this.defaultParagraphSeparator = 'p';
 
         this.buttons = settings.buttons;
 
@@ -143,11 +144,17 @@ export class FormieRichText {
 
         const options = {
             element: this.$container,
-            defaultParagraphSeparator: 'p',
+            defaultParagraphSeparator: this.defaultParagraphSeparator,
             styleWithCSS: true,
             actions: this.getButtons(),
             onChange: (html) => {
-                this.$field.textContent = html;
+                // catch "empty" HTML if we're using a placeholder
+                if (this.$field.placeholder && html === `<${this.defaultParagraphSeparator}><br></${this.defaultParagraphSeparator}>`) {
+                    this.$field.textContent = "";
+                    this.editor.content.innerHTML = "";
+                } else {
+                    this.$field.textContent = html;
+                }
 
                 // Fire a custom event on the input
                 this.$field.dispatchEvent(new CustomEvent('populate', { bubbles: true }));
@@ -170,6 +177,9 @@ export class FormieRichText {
         });
 
         this.$field.dispatchEvent(beforeInitEvent);
+
+        // save the defaultParagraphSeparator again, if it changed
+        this.defaultParagraphSeparator = options.defaultParagraphSeparator || this.defaultParagraphSeparator;
 
         this.editor = init(options);
 

--- a/src/web/assets/frontend/src/scss/fields/_rich-text.scss
+++ b/src/web/assets/frontend/src/scss/fields/_rich-text.scss
@@ -98,3 +98,8 @@
     }
 }
 
+// Add placeholder
+.fui-rich-text-content[data-placeholder]:empty::before {
+    content: attr(data-placeholder);
+}
+


### PR DESCRIPTION
This PR adds the already existing placeholder on the multi-line text form field to the Rich Text editor by configuring the Pell onChange function, the SCSS for the .fui-rich-text-content class, and the appropriate Twig template.

This feature emulates a moderately popular [PR](https://github.com/jaredreich/pell/pull/140) on the Pell repository, but rather than configuring Pell with different options, I chose to modify the onChange function to handle the empty HTML.