### PR TITLE
Move data-placeholder assignment to Pell editor initialization

### DIFF
--- a/src/templates/_formfields/multi-line-text/input.html
+++ b/src/templates/_formfields/multi-line-text/input.html
@@ -5,7 +5,7 @@
 
 {% block field %}
     {% if field.useRichText %}
-        <div class="fui-rich-text" data-rich-text {% if field.placeholder %} data-placeholder="{{ field.placeholder}}" {% endif %}></div>
+        <div class="fui-rich-text" data-rich-text></div>
 
         <div style="display: none !important;">
             {% include '_includes/forms/textarea' with { rows: 5 } %}

--- a/src/web/assets/frontend/src/js/fields/rich-text.js
+++ b/src/web/assets/frontend/src/js/fields/rich-text.js
@@ -186,6 +186,11 @@ export class FormieRichText {
         // Populate any values initially set
         this.editor.content.innerHTML = this.$field.textContent;
 
+        // Populate placeholder if set
+        if (this.$field.placeholder) {
+            this.editor.content.setAttribute('data-placeholder', this.$field.placeholder);
+        }
+
         // Emit an "afterInit" event
         this.$field.dispatchEvent(new CustomEvent('afterInit', {
             bubbles: true,


### PR DESCRIPTION
This PR updates #1655 by moving the assignment of the data-placeholder attribute to the proper location, the rich-text.js file.