### PR TITLE
Initial cloud compatibility

### DIFF
--- a/src/web/assets/frontend/FrontendAsset.php
+++ b/src/web/assets/frontend/FrontendAsset.php
@@ -1,0 +1,26 @@
+<?php
+namespace verbb\formie\web\assets\frontend;
+
+use craft\web\AssetBundle;
+
+class FrontendAsset extends AssetBundle
+{
+    // Public Methods
+    // =========================================================================
+
+    public function init(): void
+    {
+        $this->sourcePath = '@verbb/formie/web/assets/frontend/dist';
+
+        $this->js = [
+            'js/formie.js',
+        ];
+
+        $this->css = [
+            'css/formie-base.css',
+            'css/formie-theme.css',
+        ];
+
+        parent::init();
+    }
+}


### PR DESCRIPTION
Frontend assets, whether CP or not, need to be defined in an asset bundle to be compatible with Craft Cloud: https://craftcms.com/knowledge-base/cloud-plugin-development#other-best-practices

Technically, this makes Formie compatible with Cloud, even though the asset bundle never ends up being used via `\craft\web\View::registerAssetBundle`, because all we really need to know is the `sourcePath` so we can publish that to our CDN.

You may want to go further, and replace calls to `getPublishedUrl` to actually using the asset bundle, but I'll leave that to you.