### PR TITLE
nystudio107/craft-plugin-vite version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "html2text/html2text": "^4.3",
         "league/html-to-markdown": "^4.10 || ^5.0",
         "moneyphp/money": "^4.0",
-        "nystudio107/craft-plugin-vite": "dev-develop-v5 as 5.0.0-beta.1",
+        "nystudio107/craft-plugin-vite": "^5.0.0-beta.1",
         "stripe/stripe-php": "^7.0 || ^8.0 || ^9.0 || ^10.0",
         "symfony/expression-language": "^5.3.0",
         "verbb/auth": "^2.0.0-beta.1",


### PR DESCRIPTION
updated the nystudio107/craft-plugin-vite version requirement so it'll work with newer version of the plugin