### PR TITLE
Fixed a typo in Turnstile appearance settings

### DIFF
--- a/src/templates/integrations/captchas/turnstile/_plugin-settings.html
+++ b/src/templates/integrations/captchas/turnstile/_plugin-settings.html
@@ -90,7 +90,7 @@
         value: 'execute',
         label: 'Execute' | t('formie'),
     }, {
-        value: 'interation-only',
+        value: 'interaction-only',
         label: 'Interaction Only' | t('formie'),
     }],
     warning: macros.configWarning('appearance', 'formie'),


### PR DESCRIPTION
I missed a typo in the Turnstile appearance setting, which throws an error in the console and prevents Turnstile from loading.