### PR TITLE
Remove reference to infected polyfill.io script

### DIFF
--- a/docs/template-guides/cached-forms.md
+++ b/docs/template-guides/cached-forms.md
@@ -58,9 +58,6 @@ While we recommend using our `Formie.refreshForCache` function, you're more than
 
 {{ craft.formie.renderForm(form) }}
 
-{# Ensure we load polyfills for older browsers that don't support `fetch()` #}
-<script src="https://cdn.polyfill.io/v2/polyfill.js?features=fetch,Promise"></script>
-
 <script>
     // Wait until the DOM is ready
     document.addEventListener('DOMContentLoaded', (event) => {


### PR DESCRIPTION
Hi!

The [documentation](https://verbb.io/craft-plugins/formie/docs/template-guides/cached-forms) mentions a reference to polyfill.io, which was recently [found to be infected](https://sansec.io/research/polyfill-supply-chain-attack).

This PR removes the reference entirely, as [fetch](https://caniuse.com/fetch) and [promises](https://caniuse.com/promises) are now supported by most major browsers.