### PR TITLE
Look for payment field in Formie fields instead of Craft fields

### DIFF
--- a/src/models/Payment.php
+++ b/src/models/Payment.php
@@ -73,7 +73,7 @@ class Payment extends Model
     public function getField(): ?PaymentField
     {
         if (!isset($this->_field)) {
-            $this->_field = Craft::$app->getFields()->getFieldById($this->fieldId);
+            $this->_field = Formie::$plugin->getFields()->getFieldById($this->fieldId);
         }
 
         return $this->_field;


### PR DESCRIPTION
The Payment model's getField method still tries to find the payment field id in Craft's fields instead of Formie's fields making the result always null. 
This update exchanges Craft's getFieldById for Formie's