### PR TITLE
Prevents unnecessary sesssion_start() calls to improve cacheabilty

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -3,6 +3,7 @@ namespace verbb\formie\services;
 
 use Craft;
 
+use craft\helpers\Session;
 use yii\base\Component;
 
 class Service extends Component
@@ -12,12 +13,20 @@ class Service extends Component
 
     public function setFlash(string $namespace, string $key, mixed $value, bool $removeAfterAccess = true): void
     {
+        if (!Session::exists()) {
+            return;
+        }
+
         $key = "formie.$namespace:$key";
         Craft::$app->getSession()->setFlash($key, $value, $removeAfterAccess);
     }
 
     public function getFlash(string $namespace, string $key, mixed $defaultValue = null, bool $delete = false): mixed
     {
+        if (!Session::exists()) {
+            return $defaultValue;
+        }
+
         $key = "formie.$namespace:$key";
         return Craft::$app->getSession()->getFlash($key, $defaultValue, $delete);
     }


### PR DESCRIPTION
Whenever a request results in a `session_start()` call, the response will become un-cacheable, as it will cause `Cache-Control: no-store, no-cache, must-revalidate` will be sent (based on `[session.cache_limiter](https://www.php.net/manual/en/session.configuration.php#ini.session.cache-limiter)`).

These headers prevent browsers, as well as caching proxies (e.g. Craft Cloud) from caching the response. So, we want to be careful about calling code that may needlessly open a session before it really needs to.

There are 2 things present in Formie's default template that that trigger this behavior:
- `csrfInput`: https://github.com/verbb/formie/blob/craft-5/src/templates/_special/form-template/form.html#L44
  - To prevent this, users can set `asyncCsrfInputs` https://craftcms.com/docs/5.x/reference/config/general.html#asynccsrfinputs
- Calls to `craft.formie.plugin.service.getFlash`: https://github.com/verbb/formie/blob/craft-5/src/templates/_special/form-template/form.html#L22-L24
  - What the PR addresses: Before attempting to get flash data from session (which will always call `session_start()`), it will first check if the request has a session at all. The result is initial requests wont trigger a `session_start()` and thus will be cacheable.

## Notes
`\craft\helpers\Session` contains helpers for this behavior, but unfortunately doesn't have specific methods like `getFlash`. We will work on adding these in Craft, so your plugin could just call `\craft\helpers\Session::getFlash` and you wouldn't have to explicitly worry about it.