### PR TITLE
Update formie.js asset bundle path for Craft Cloud compatibility

### DIFF
--- a/src/templates/submissions/_edit.html
+++ b/src/templates/submissions/_edit.html
@@ -4,7 +4,7 @@
 
 {% do view.registerAssetBundle('verbb\\formie\\web\\assets\\cp\\CpAsset') -%}
 
-{% set jsFile = view.getAssetManager().getPublishedUrl('@verbb/formie/web/assets/frontend/', true, 'dist/js/formie.js') %}
+{% set jsFile = view.getAssetManager().getPublishedUrl('@verbb/formie/web/assets/frontend/dist/', true, 'js/formie.js') %}
 {% do view.registerJsFile(jsFile) %}
 
 {% set isNew = submission.id ? false : true %}


### PR DESCRIPTION
Related to: #2157 

This should fix the 404 error on the formie.js Asset Bundle to be compatible with Craft Cloud and its artifacts/CDN deploy.

This is specifically in the CP context not frontend.