### PR TITLE
Attempt to fix the Freefrom 5 importer

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -1478,6 +1478,7 @@ abstract class Field extends SavableComponent implements CraftFieldInterface, Fi
         $rules[] = [['label', 'handle'], 'required'];
         $rules[] = [['placeholder', 'errorMessage', 'cssClasses'], 'string', 'max' => 255];
         $rules[] = [['handle'], HandleValidator::class, 'reservedWords' => $this->getReservedHandles()];
+        $rules[] = [['handle'], 'string', 'max' => 64];
 
         $rules[] = [
             ['handle'],

--- a/src/console/controllers/MigrateController.php
+++ b/src/console/controllers/MigrateController.php
@@ -82,7 +82,7 @@ class MigrateController extends Controller
         foreach ($formIds as $formId) {
             $this->stderr('Migrating Freeform form #' . $formId . PHP_EOL, Console::FG_GREEN);
 
-            $migration = new MigrateFreeform(['formId' => $formId]);
+            $migration = new MigrateFreeform4(['formId' => $formId]);
             $migration->setConsoleRequest($this);
             $migration->up();
         }
@@ -110,7 +110,7 @@ class MigrateController extends Controller
         foreach ($formIds as $formId) {
             $this->stderr('Migrating Freeform form #' . $formId . PHP_EOL, Console::FG_GREEN);
 
-            $migration = new MigrateFreeform(['formId' => $formId]);
+            $migration = new MigrateFreeform5(['formId' => $formId]);
             $migration->setConsoleRequest($this);
             $migration->up();
         }

--- a/src/fields/FileUpload.php
+++ b/src/fields/FileUpload.php
@@ -837,7 +837,8 @@ class FileUpload extends ElementField
     {
         $sourceKey = $this->uploadLocationSource;
 
-        if ($sourceKey && str_starts_with($sourceKey, 'volume:')) {
+
+        if ($sourceKey && (str_starts_with($sourceKey, 'volume:') || str_starts_with($sourceKey, 'folder:'))) {
             $parts = explode(':', $sourceKey);
 
             return Craft::$app->getVolumes()->getVolumeByUid($parts[1]);

--- a/src/models/FieldLayout.php
+++ b/src/models/FieldLayout.php
@@ -25,6 +25,7 @@ class FieldLayout extends SavableComponent
     // =========================================================================
 
     public ?string $uid = null;
+    public ?string $type = null;
 
     private array $_deletedItems = [];
     private array $_pages = [];

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -827,6 +827,7 @@ class Fields extends Component
         $fieldRecord->save(false);
 
         $field->id = $fieldRecord->id;
+        $field->uid = $fieldRecord->uid;
 
         $field->afterSave($isNewField);
 

--- a/src/validators/HandleValidator.php
+++ b/src/validators/HandleValidator.php
@@ -41,4 +41,23 @@ class HandleValidator extends Validator
             }
         }
     }
+
+    public function validateValue($value): ?array
+    {
+        $reservedWords = array_map('strtolower', $this->reservedWords);
+        $lcHandle = strtolower($value);
+
+        if (in_array($lcHandle, $reservedWords, true)) {
+            return [Craft::t('app', '“{handle}” is a reserved word.', ['handle' => $value]), []];
+        } else {
+            if (!preg_match('/^' . static::$handlePattern . '$/', $value)) {
+                $altMessage = Craft::t('app', '“{handle}” isn’t a valid handle.', ['handle' => $value]);
+                $message = $this->message ?? $altMessage;
+
+                return [$message, []];
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
The Freeform importer is currently broken, this due to some typo's and some missing/wrong implementation.
This is an (initial) attempt to fix this.

Fixes
- MigrateFreeform console command typos
- Fileupload locations in Freeform can be either `volume:` or `folder:` followed by the uid
- Use Craft Element service to save the form
- Form FieldLayoutBuilder
- Newly generated fields not getting the Record's uid, resulting in the submission's content field having empty keys for each value

Adds
- Field handle validation max 64 characters based on the fields db constraints
- Extra check for Notification template, if none is defined the notification cannot be migrated
- Notification handle mapping, so midscores are replaced with underscores
- Default field handle generator for completely invalid field handles


These changes helped us migrate 40 forms with +- 10.000 submissions. Though there could still be some edge cases left.