### PR TITLE
Fix Pardot integration

### DIFF
--- a/src/integrations/crm/Pardot.php
+++ b/src/integrations/crm/Pardot.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace verbb\formie\integrations\crm;
 
 use verbb\formie\Formie;
@@ -45,11 +46,11 @@ class Pardot extends Crm implements OAuthProviderInterface
     {
         return Craft::t('formie', 'Pardot');
     }
-    
+
 
     // Properties
     // =========================================================================
-    
+
     public ?string $businessUnitId = null;
     public bool|string $useSandbox = false;
     public bool $mapToProspect = false;
@@ -77,7 +78,7 @@ class Pardot extends Crm implements OAuthProviderInterface
     {
         $prefix = $this->getUseSandbox() ? 'pi.demo' : 'pi';
 
-        return "https://{$prefix}.pardot.com/api/";
+        return "https://{$prefix}.pardot.com/api";
     }
 
     public function getDescription(): string
@@ -85,13 +86,17 @@ class Pardot extends Crm implements OAuthProviderInterface
         return Craft::t('formie', 'Manage your {name} customers by providing important information on their conversion on your site.', ['name' => static::displayName()]);
     }
 
-    public function getOAuthProviderConfig(): array
+    public function getAuthorizationUrlOptions(): array
     {
-        $config = parent::getOAuthProviderConfig();
-        $config['domain'] = $this->getApiDomain();
-        $config['baseApiUrl'] = $this->getApiDomain();
+        $options = parent::getAuthorizationUrlOptions();
 
-        return $config;
+        $options['scope'] = [
+            'api',
+            'pardot_api',
+            'refresh_token',
+        ];
+
+        return $options;
     }
 
     public function request(string $method, string $uri, array $options = []): mixed
@@ -489,7 +494,7 @@ class Pardot extends Crm implements OAuthProviderInterface
                 $trackingData[$key] = $value;
             }
         }
-        
+
         $this->context['pardot_tracking'] = $trackingData;
     }
 


### PR DESCRIPTION
While trying to connect the Pardot integration in our project, we were consistently getting an [access denied error](https://developer.salesforce.com/docs/marketing/pardot/guide/error-codes.html#error-code-49). We double-checked our Salesforce/Pardot app configuration (OAuth settings, OAuth policy, consumer key and secret, etc.), but we kept encountering the same error. We eventually identified that part of the issue was caused by the domain used for authentication: it was using the Pardot API domain instead of Salesforce.

Here’s an example of the URL used when trying to connect the Pardot integration:

```bash
https://pi.pardot.com/api//services/oauth2/authorize?state=[state]&scope=&response_type=code&approval_prompt=auto&redirect_uri=[redirect_uri]&client_id=[client_id]
```

And here’s the response:

```json
{
  "@attributes": {
    "stat": "fail",
    "version": 1,
    "err_code": 49
  },
  "err": "Access Denied"
}
```

As described in the [documentation](https://developer.salesforce.com/docs/marketing/pardot/guide/authentication.html), the domain used for OAuth authentication must be Salesforce’s domain. Once the token is retrieved, the Pardot/Account Engagement domain should then be used. Additionally, the `pardot_api` scope must be provided.

This PR adjusts the implementation to use the current provider (`SalesforceProvider`) configuration instead of overriding it with the API domain. It also adds the required scope for authentication.

With these changes, we are now able to connect the Pardot integration successfully and use the form handlers functionality. Both our team and our client are happy 😄