### PR TITLE
Fix issue with custom Lead fields in Copper

### DIFF
--- a/src/integrations/crm/Copper.php
+++ b/src/integrations/crm/Copper.php
@@ -469,7 +469,7 @@ class Copper extends Crm
 
             if ($this->mapToLead) {
                 $leadPayload = array_merge($leadValues, [
-                    'custom_fields' => $peopleFields,
+                    'custom_fields' => $leadFields,
                 ]);
 
                 $response = $this->deliverPayload($submission, 'leads', $leadPayload);


### PR DESCRIPTION
The Copper integration isn't passing through custom fields for leads. Wrong field array being passed to the payload