### PR TITLE
Fix typo with RegisterDateTimeFormatOptionsEvent

### DIFF
--- a/docs/developers/events.md
+++ b/docs/developers/events.md
@@ -845,11 +845,11 @@ Event::on(Date::class, Date::EVENT_MODIFY_TIME_FORMAT, function(ModifyDateTimeFo
 The event that is triggered to register the available options to select for date formatting.
 
 ```php
-use verbb\formie\events\RegisterDateTimeFormatOpionsEvent;
+use verbb\formie\events\RegisterDateTimeFormatOptionsEvent;
 use verbb\formie\fields\Date;
 use yii\base\Event;
 
-Event::on(Date::class, Date::EVENT_REGISTER_DATE_FORMAT_OPTIONS, function(RegisterDateTimeFormatOpionsEvent $event) {
+Event::on(Date::class, Date::EVENT_REGISTER_DATE_FORMAT_OPTIONS, function(RegisterDateTimeFormatOptionsEvent $event) {
     $event->options[] = ['label' => 'Standard Formatting', 'value' => 'Y-m-d'];
 });
 ```
@@ -858,11 +858,11 @@ Event::on(Date::class, Date::EVENT_REGISTER_DATE_FORMAT_OPTIONS, function(Regist
 The event that is triggered to register the available options to select for time formatting.
 
 ```php
-use verbb\formie\events\RegisterDateTimeFormatOpionsEvent;
+use verbb\formie\events\RegisterDateTimeFormatOptionsEvent;
 use verbb\formie\fields\Date;
 use yii\base\Event;
 
-Event::on(Date::class, Date::EVENT_REGISTER_TIME_FORMAT_OPTIONS, function(RegisterDateTimeFormatOpionsEvent $event) {
+Event::on(Date::class, Date::EVENT_REGISTER_TIME_FORMAT_OPTIONS, function(RegisterDateTimeFormatOptionsEvent $event) {
     $event->options[] = ['label' => 'Standard Formatting', 'value' => 'H:i:s'];
 });
 ```

--- a/src/events/RegisterDateTimeFormatOptionsEvent.php
+++ b/src/events/RegisterDateTimeFormatOptionsEvent.php
@@ -5,7 +5,7 @@ use verbb\formie\base\FieldInterface;
 
 use yii\base\Event;
 
-class RegisterDateTimeFormatOpionsEvent extends Event
+class RegisterDateTimeFormatOptionsEvent extends Event
 {
     // Properties
     // =========================================================================
@@ -14,3 +14,9 @@ class RegisterDateTimeFormatOpionsEvent extends Event
     public array $options = [];
     
 }
+
+class_alias(
+    RegisterDateTimeFormatOptionsEvent::class,
+    RegisterDateTimeFormatOpionsEvent::class
+);
+

--- a/src/fields/Date.php
+++ b/src/fields/Date.php
@@ -10,7 +10,7 @@ use verbb\formie\base\SubFieldInterface;
 use verbb\formie\base\SubField;
 use verbb\formie\elements\Submission;
 use verbb\formie\events\ModifyDateTimeFormatEvent;
-use verbb\formie\events\RegisterDateTimeFormatOpionsEvent;
+use verbb\formie\events\RegisterDateTimeFormatOptionsEvent;
 use verbb\formie\events\ModifyFrontEndSubFieldsEvent;
 use verbb\formie\fields\subfields\DateYear;
 use verbb\formie\gql\types\generators\FieldAttributeGenerator;
@@ -1472,7 +1472,7 @@ class Date extends SubField implements PreviewableFieldInterface, SortableFieldI
             ['label' => 'DD.MM.YYYY', 'value' => 'd.m.Y'],
         ];
 
-        $event = new RegisterDateTimeFormatOpionsEvent([
+        $event = new RegisterDateTimeFormatOptionsEvent([
             'field' => $this,
             'options' => $options,
         ]);
@@ -1491,7 +1491,7 @@ class Date extends SubField implements PreviewableFieldInterface, SortableFieldI
             ['label' => '59:59 (MM:SS)', 'value' => 'i:s'],
         ];
 
-        $event = new RegisterDateTimeFormatOpionsEvent([
+        $event = new RegisterDateTimeFormatOptionsEvent([
             'field' => $this,
             'options' => $options,
         ]);


### PR DESCRIPTION
The `RegisterDateTimeFormatOptionsEvent` has a typo in the class name.

This renames the class, but also adds in a class_alias due to the likelihood of some projects using the typo class name in events and not to cause breakage in a minor update release.