### PR TITLE
Fix undefined method StringHelper::cleanString() causing email notifications to fail

### DIFF
--- a/src/services/Emails.php
+++ b/src/services/Emails.php
@@ -248,7 +248,7 @@ class Emails extends Component
             $parsedContent = Variables::getParsedValue($notification->getParsedContent(), $submission, $form, $notification, true);
 
             // Add it to our render variables
-            $renderVariables['contentHtml'] = Template::raw(StringHelper::cleanString($parsedContent));
+            $renderVariables['contentHtml'] = Template::raw(StringHelper::toString($parsedContent));
 
             $event = new MailRenderEvent([
                 'email' => $newEmail,


### PR DESCRIPTION
## Description
This PR fixes an error that occurs when sending notification emails in the Formie plugin. The error occurs because the code calls a non-existent method `StringHelper::cleanString()`, which causes notifications to fail with the error message:

```
Failed to send notification email: {"error":"Notification email template parse error for "". Template error: "Call to undefined method craft\helpers\StringHelper::cleanString()" /vendor/verbb/formie/src/services/Emails.php:251"}
```

## Changes
- Replace the call to the non-existent `StringHelper::cleanString()` method with `StringHelper::toString()`, which is a valid method that safely converts the parsed content to a string

## Testing Instructions
1. Create a form with an email notification
2. Submit the form
3. Verify that the notification email is sent successfully without errors

## Additional Notes
This issue likely started occurring after updating Formie to Version 2.1.46 (for Craft CMS 4.15.2)