### PR TITLE
fix(Recaptcha): misleading spam reason logging

### DIFF
--- a/src/integrations/captchas/Recaptcha.php
+++ b/src/integrations/captchas/Recaptcha.php
@@ -238,16 +238,7 @@ class Recaptcha extends Captcha
 
             Formie::error(Craft::t('formie', '{token}:{spamReason}', [
                 'token' => $responseToken,
-                'spamReason' => Json::encode($result),
-            ]));
-        }
-
-        if (!$this->spamReason) {
-            $this->spamReason = 'Captcha validation failed.';
-
-            Formie::error(Craft::t('formie', '{token}:{spamReason}', [
-                'token' => $responseToken,
-                'spamReason' => Json::encode($result),
+                'spamReason' => $this->spamReason,
             ]));
         }
 


### PR DESCRIPTION
It was not checked for successful response, just for existence of spam reason. So in any successful regular captcha case, this condition was met and formie logged a Craft error message. This flooded web logs for no reason. Because the case of failed captcha or captcha score are both handled before, it is safe to remove the generic "Captcha validation failed." case altogether.