### PR TITLE
Fixed type error during sending of Freshdesk payload

### DIFF
--- a/src/integrations/helpdesk/Freshdesk.php
+++ b/src/integrations/helpdesk/Freshdesk.php
@@ -495,13 +495,13 @@ class Freshdesk extends HelpDesk
 
     public function getFieldMappingValues(Submission $submission, $fieldMapping, $fieldSettings = [], bool $multipart = false)
     {
-        // If multipart isn't required, just use verbb\formie\base\Crm::getFieldMappingValues
+        $fieldSettings = $this->getFormSettingValue($fieldSettings);
+
+        // If multipart isn't required, just use verbb\formie\base\Integration::getFieldMappingValues()
         if (!$multipart) {
             return parent::getFieldMappingValues($submission, $fieldMapping, $fieldSettings);
         }
 
-        // Manually get field settings since we're not using parent method
-        $fieldSettings = $this->getFormSettingValue($fieldSettings);
         $fieldValues = [];
 
         if (!is_array($fieldMapping)) {


### PR DESCRIPTION
The `getFieldMappingValues()` method in the `Freshdesk` integration originally relied on the logic of [`Crm::getFieldMappingValues()`](https://github.com/verbb/formie/blob/3725bbe80167ebb11abd662616b3b032305c87fc/src/base/Crm.php#L67-L77) to get form settings from the namespace string. Since the namespace and inheritance of `Freshdesk` changed, this is no longer available, resulting in a type error being thrown by [`ArrayHelper::firstWhere()` in `Integration::getFieldMappingValues()`](https://github.com/verbb/formie/blob/3725bbe80167ebb11abd662616b3b032305c87fc/src/base/Integration.php#L655). I updated `Freshdesk` to mirror other helpdesk integrations and call `getFormSettingValue()` in its own `getFieldMappingValues()` method.