### PR TITLE
Make the url encoding keep the ampersand unencoded

### DIFF
--- a/src/elements/Form.php
+++ b/src/elements/Form.php
@@ -1044,7 +1044,7 @@ class Form extends Element
         }
 
         // Handle any special characters defined in the URL and encode them properly
-        $url = htmlspecialchars($url);
+        $url = str_replace("&amp;", "&", htmlspecialchars($url));
 
         return $url;
     }


### PR DESCRIPTION
The new 3.1.4 release changed the way the redirect url is encoded. Using the htmlspecialchars function is encoding the ampersand character that is used with urls to separate parameters. So instead of having a clean ampersand "&" character now it's encoded to `&amp;`. This creates an issue when the form redirects after being submitted because url parameters cannot be parsed reliably.

Eg. of an url being encoded: `https://mywebsite.com/redirect-page?param1=abc&param2=cde&param3=fgh`

will be encoded to: `https://mywebsite.com/redirect-page?param1=abc&amp;param2=cde&amp;param3=fgh`

then if you try to retrieve the url parameters from the redirected page using the function `craft.app.request.getQueryParam('param3')` you will get a null value because param 3 now became `amp;param3`

The fix replaces the encoded ampersand from `&amp;` to "&". If no `&amp;` characters is in the redirect url it will simply do nothing.
