### PR TITLE
Replace deprecated Craft.appendFootHtml() for repeater.js

### DIFF
--- a/src/templates/_formfields/repeater/input.html
+++ b/src/templates/_formfields/repeater/input.html
@@ -49,7 +49,7 @@
                 var id = 'new' + e.detail.repeater.getNumRows();
                 var js = '{{ footHtml | e('js') }}'.replace(/__ROW__/g, id);
                 
-                Craft.appendFootHtml(js);
+                Craft.appendBodyHtml(js);
                 Craft.initUiElements($repeaterField);
             });
         }


### PR DESCRIPTION
The repeater field JS calls `Craft.appendFootHtml()` which throws a JS deprecation error. This updates the call `Craft.appendBodyHtml()` to remove the console warning.