### PR TITLE
Event to modify migration address config

### DIFF
--- a/src/events/ModifyMigrationAddressConfigEvent.php
+++ b/src/events/ModifyMigrationAddressConfigEvent.php
@@ -1,0 +1,13 @@
+<?php
+namespace verbb\formie\events;
+
+use yii\base\Event;
+
+class ModifyMigrationAddressConfigEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    public array $settings = [];
+    public array $addressConfig = [];
+}

--- a/src/migrations/m231125_000000_craft5.php
+++ b/src/migrations/m231125_000000_craft5.php
@@ -2,6 +2,7 @@
 namespace verbb\formie\migrations;
 
 use verbb\formie\Formie;
+use verbb\formie\events\ModifyMigrationAddressConfigEvent;
 use verbb\formie\fields;
 use verbb\formie\fields\Group;
 use verbb\formie\fields\Repeater;
@@ -26,6 +27,11 @@ use Throwable;
 
 class m231125_000000_craft5 extends BaseContentRefactorMigration
 {
+    // Constants
+    // =========================================================================
+
+    public const EVENT_MODIFY_MIGRATION_ADDRESS_CONFIG = 'modifyMigrationAddressConfig';
+
     // Properties
     // =========================================================================
 
@@ -895,7 +901,8 @@ class m231125_000000_craft5 extends BaseContentRefactorMigration
 
     private function _getAddressConfig(array $settings): array
     {
-        return [
+
+        $addressConfig = [
             [
                 'fields' => [
                     [
@@ -1066,6 +1073,15 @@ class m231125_000000_craft5 extends BaseContentRefactorMigration
                 ],
             ],
         ];
+
+        // Fire a 'ModifyMigrationAddressConfig' event
+        $event = new ModifyMigrationAddressConfigEvent([
+            'addressConfig' => $addressConfig,
+            'settings' => $settings,
+        ]);
+        $this->trigger(self::EVENT_MODIFY_MIGRATION_ADDRESS_CONFIG, $event);
+
+        return $event->addressConfig;
     }
 
     private function _getDateCalendarConfig(array $settings): array


### PR DESCRIPTION
I'm updating all of my projects from 4 to 5. 

To change the order of the subfields city and zip. I use the `Address::EVENT_MODIFY_FRONT_END_SUBFIELDS` event added for the issue [490](https://github.com/verbb/formie/issues/490).
This only changes the order in the frontend.

With the new version of Formie, it is now possible to change the order of the subField in the backend.
But the migration script `m231125_000000_craft5` is using the default order, and I couldn't find a way to override this.
Changing the order in the backend after the update would take hours.

Can you merge my pull request so I can migrate all my projects with my custom order?

Thanks, 
Megafry


```php
use yii\base\Event;
use verbb\formie\events\ModifyMigrationAddressConfigEvent;
use verbb\formie\migrations\m231125_000000_craft5 as MigrationsCraft5;

 Event::on(MigrationsCraft5::class, MigrationsCraft5::EVENT_MODIFY_MIGRATION_ADDRESS_CONFIG, function (ModifyMigrationAddressConfigEvent $event) {
 // $event->addressConfig = 
});
```