### PR TITLE
Replace log() with info() to fix deprecation error

### DIFF
--- a/src/integrations/captchas/Recaptcha.php
+++ b/src/integrations/captchas/Recaptcha.php
@@ -225,7 +225,7 @@ class Recaptcha extends Captcha
         $result = Json::decode((string)$response->getBody(), true);
         $success = $result['success'] ?? false;
 
-        Formie::log('ReCAPTCHA result {result}', [
+        Formie::info('ReCAPTCHA result {result}', [
             'result' => Json::encode($result),
         ]);
 


### PR DESCRIPTION
Fix deprecation error for recaptcha integration

Fixes #2655 