### PR TITLE
Fix Make the url encoding keep the ampersand unencoded

### DIFF
--- a/src/elements/Form.php
+++ b/src/elements/Form.php
@@ -1276,7 +1276,7 @@ class Form extends Element
         }
 
         // Handle any special characters defined in the URL and encode them properly
-        $url = htmlspecialchars($url);
+        $url = str_replace("&amp;", "&", htmlspecialchars($url));
 
         return $url;
     }


### PR DESCRIPTION
The redirectUrl encoding breaks ampersands for query string parameters in the URL. It is encoding from `&` -> `&amp;` leaving the query string variables inaccessible on the redirectUrl page.

Example:
`/submit?name=Test&id=123&topic=Code`
Becomes
`/submit?name=Test&amp;id=123&amp;topic=Code`
