### PR TITLE
Fix Date with Text Inputs submission after 3.1.7

### DIFF
--- a/src/fields/subfields/DateNumber.php
+++ b/src/fields/subfields/DateNumber.php
@@ -16,9 +16,7 @@ class DateNumber extends Number implements SubFieldInnerFieldInterface
 
     public function validateDateNumber(ElementInterface $element): void
     {
-        $value = $element->getFieldValue($this->fieldKey);
-
-        $dateValue = (int)$value->format($this->validationFormatParam);
+        $dateValue = $element->getFieldValue($this->fieldKey);
 
         if ($this->_isNotNumber($dateValue)) {
             $element->addError($this->fieldKey, Craft::t('formie', '{attribute} is invalid.', ['attribute' => $this->label]));


### PR DESCRIPTION
When trying to submit a form using a Date field with Text Inputs as display type the following error is thrown starting with Formie 3.1.7

"Call to a member function format() on int" 
/vendor/verbb/formie/src/fields/subfields/DateNumber.php line 21

This is because `$element->getFieldValue($this->fieldKey);` now directly returns the subfield's int value instead of the DateTime object.

This just removes the extra formatting line that throws the error and isn't necessary anymore.