### PR TITLE
Fix Stripe `Submissions::EVENT_AFTER_SUBMISSION` triggered on the wrong class

### DIFF
--- a/src/integrations/payments/Stripe.php
+++ b/src/integrations/payments/Stripe.php
@@ -613,7 +613,7 @@ class Stripe extends Payment
                 'submitAction' => 'submit',
                 'success' => true,
             ]);
-            $this->trigger(Submissions::EVENT_AFTER_SUBMISSION, $event);
+            Formie::$plugin->getSubmissions()->trigger(Submissions::EVENT_AFTER_SUBMISSION, $event);
 
             if (!$submission->isIncomplete) {
                 if ($event->success) {


### PR DESCRIPTION
I think there is a bug with the `Submissions::EVENT_AFTER_SUBMISSION`.

This causes event listeners to not be called when getting redirected to `process-callback`.