### PR TITLE
Fix Repeater conditional fields showing the wrong row's value in email notifications

### DIFF
--- a/src/templates/_special/email-template/fields/repeater.html
+++ b/src/templates/_special/email-template/fields/repeater.html
@@ -25,6 +25,10 @@
                         {% do field.setParentField(repeaterField, loop.parent.loop.index0) %}
 
                         {% if not field.isConditionallyHidden(submission) %}
+                            {# Re-apply the namespace, as evaluating conditions re-iterates the repeater's rows
+                               on the shared inner field instances, leaving the namespace at the last row #}
+                            {% do field.setParentField(repeaterField, loop.parent.loop.index0) %}
+
                             {% set fieldValue = submission.getFieldValue(field.fieldKey) ?? field.normalizeValue(field.getDefaultValue(), null) %}
 
                             {% set html = field.getEmailHtml(submission, notification, fieldValue) %}


### PR DESCRIPTION
The 3.1.28 fix for conditional fields inside Repeaters (the `__ROW__` evaluation in email templates) got the field *showing* again — but it now renders the **last row's value for every row** when the notification uses "All Form Fields".

### Reproduce

1. Form with a Repeater containing a Dropdown and a Single-Line Text field
2. Condition on the text field: show when the dropdown is a certain value
3. Email notification with the **All Form Fields** variable in the body
4. Submit with two rows, both matching the condition, different text in each (say "first" and "second")

Expected: Row 1 → "first", Row 2 → "second"
Actual: both rows → "second"

Non-conditional fields in the same rows are fine, and Groups aren't affected — it's specifically conditional fields inside Repeaters.

### What's happening

In `repeater.html`, the template sets the row context and then checks `field.isConditionallyHidden(submission)` before looking up the value. The trouble is that evaluating the condition ends up calling the Repeater's `getValueForCondition()` (via `ConditionsHelper::getSerializedFieldValues()`), and both that method's row loop *and* the `getFields()` call inside it call `setParentField()` on the shared inner field instances. By the time the template gets to `submission.getFieldValue(field.fieldKey)`, the field's namespace is pointing at the last row — so every row renders the last row's value. (Row 2 of 2 looks correct, but only by coincidence.)

### Fix

Re-apply the row namespace after the `isConditionallyHidden()` check, right before the value lookup. One line fix effectively, plus a comment and line break — and I've verified it end-to-end against a real form (two rows captured in Mailpit: wrong before, correct per-row after).

A deeper fix would be making condition evaluation side-effect-free on the shared instances (same shared-instance issue that `validateBlocks()` and `modifyAttributeLabels()` already work around with their restore patterns), but that touches `NestedField::getFields()` and the whole value pipeline, so I kept this surgical.

Happy to provide more info if needed. Cheers!
