### PR TITLE
Fixed bug preventing payload send when content not multipart

### DIFF
--- a/src/integrations/helpdesk/Freshdesk.php
+++ b/src/integrations/helpdesk/Freshdesk.php
@@ -389,24 +389,20 @@ class Freshdesk extends HelpDesk
 
             // Send Ticket payload
             if ($this->mapToTicket) {
-                $ticketValues = $this->getFieldMappingMultipartValues($submission, $this->ticketFieldMapping, 'ticket');
-                
                 $requiresMultipart = $this->_requiresMultipart($this->ticketFieldMapping, $submission);
 
                 if ($requiresMultipart) {
-                    $ticketPayload = $ticketValues;
+                    $ticketPayload = $this->getFieldMappingMultipartValues($submission, $this->ticketFieldMapping, 'ticket');
                     $contentType = 'multipart';
                 } else {
+                    $ticketPayload = parent::getFieldMappingValues($submission, $this->ticketFieldMapping, 'ticket');
+
                     // Directly modify the field values first
-                    $ticketFields = $this->_prepCustomFields($ticketValues);
+                    $ticketFields = $this->_prepCustomFields($ticketPayload);
 
                     // Only add custom fields if array not empty to prevent validation error
                     if ($ticketFields) {
-                        $ticketPayload = array_merge($ticketValues, [
-                            'custom_fields' => $ticketFields,
-                        ]);
-                    } else {
-                        $ticketPayload = $ticketValues;
+                        $ticketPayload['custom_fields'] = $ticketFields;
                     }
 
                     // Extra payload prep - some fields are finicky


### PR DESCRIPTION
Was running into issues where tickets would not be created in Freshdesk when multipart data wasn't required (no attachments). This PR addresses a couple things:

- `_requiresMultipart()` must be called before `getFieldMappingMultipartValues()`, otherwise it will try to loop through `$_attachments` while it's still set to `null`.
- This was using the multipart data format when trying to submit as JSON, which doesn't work because the JSON expects regular key–value pairs.

Thanks for taking a look!