### PR TITLE
Fix HandleHelper::getUniqueHandle() producing handles over max length

### DIFF
--- a/src/controllers/FormsController.php
+++ b/src/controllers/FormsController.php
@@ -205,7 +205,7 @@ class FormsController extends Controller
         $stencil->name = $this->request->getParam('title');
 
         // Resolve the handle, in case it already exists
-        $stencil->handle = HandleHelper::getUniqueHandle($stencilHandles, $handle);
+        $stencil->handle = HandleHelper::getUniqueHandle($stencilHandles, $handle, maxLength: 255);
 
         if ($templateId = $this->request->getParam('templateId')) {
             $template = Formie::$plugin->getFormTemplates()->getTemplateById($templateId);

--- a/src/controllers/StencilsController.php
+++ b/src/controllers/StencilsController.php
@@ -96,7 +96,7 @@ class StencilsController extends SettingsAccessController
 
             $stencils = Formie::$plugin->getStencils()->getAllStencils();
             $stencilHandles = ArrayHelper::getColumn($stencils, 'handle');
-            $stencil->handle = HandleHelper::getUniqueHandle($stencilHandles, $stencil->handle);
+            $stencil->handle = HandleHelper::getUniqueHandle($stencilHandles, $stencil->handle, maxLength: 255);
         }
 
         if ($templateId = $request->getParam('templateId')) {

--- a/src/elements/Form.php
+++ b/src/elements/Form.php
@@ -2031,7 +2031,7 @@ class Form extends Element
 
         // Prepare new data for the duplicated form
         return [
-            'handle' => HandleHelper::getUniqueHandle($formHandles, $this->handle),
+            'handle' => HandleHelper::getUniqueHandle($formHandles, $this->handle, maxLength: HandleHelper::getMaxFormHandle()),
             'title' => Craft::t('formie', '{title} Copy', ['title' => $this->title]),
             'formLayout' => $formLayout,
             'notifications' => $notifications,

--- a/src/helpers/HandleHelper.php
+++ b/src/helpers/HandleHelper.php
@@ -8,7 +8,7 @@ class HandleHelper
     // Static Methods
     // =========================================================================
 
-    public static function getUniqueHandle(array $handles, string $handle, int $suffix = 0)
+    public static function getUniqueHandle(array $handles, string $handle, int $suffix = 0, ?int $maxLength = null)
     {
         $newHandle = $handle;
 
@@ -16,8 +16,15 @@ class HandleHelper
             $newHandle = $handle . $suffix;
         }
 
+        // If a max length is enforced and the handle (including any suffix) would exceed it,
+        // truncate the base handle - not the suffix - so the result still fits and stays unique.
+        if ($maxLength !== null && strlen($newHandle) > $maxLength) {
+            $suffixLength = $suffix ? strlen((string)$suffix) : 0;
+            $newHandle = substr($handle, 0, $maxLength - $suffixLength) . ($suffix ?: '');
+        }
+
         if (in_array($newHandle, $handles)) {
-            return self::getUniqueHandle($handles, $handle, $suffix + 1);
+            return self::getUniqueHandle($handles, $handle, $suffix + 1, $maxLength);
         }
 
         return $newHandle;

--- a/src/helpers/ImportExportHelper.php
+++ b/src/helpers/ImportExportHelper.php
@@ -297,7 +297,7 @@ class ImportExportHelper
                 ->from(Table::FORMIE_FORMS)
                 ->column();
 
-            $json['handle'] = HandleHelper::getUniqueHandle($formHandles, $json['handle']);
+            $json['handle'] = HandleHelper::getUniqueHandle($formHandles, $json['handle'], maxLength: HandleHelper::getMaxFormHandle());
         }
 
         if ($formAction === 'update') {


### PR DESCRIPTION
When a form's handle is already at or near the DB-derived max length (`HandleHelper::getMaxFormHandle()`, e.g. 56 chars on MySQL) and a duplicate/collision forces a numeric suffix, `getUniqueHandle()` appends the suffix without checking the length limit, producing a handle 1+ characters over the ceiling. `Form::getDuplicateAttributes()` then feeds that into `duplicateElement()`, which fails Craft's `string, max` validation rule and throws:

```
InvalidElementException: Element {id} could not be duplicated because it doesn't validate.
```

This surfaces in the CP as a bare 500 with no indication of what actually went wrong.

This PR adds an optional `?int $maxLength = null` parameter to `getUniqueHandle()`. When set and the suffixed candidate would exceed it, the *base* handle (never the suffix) is truncated and the uniqueness check re-runs against the truncated result, guaranteeing a valid, unique handle. Default `null` preserves existing behavior exactly for any caller that doesn't opt in — fully backwards compatible.

The four call sites that generate form/stencil handles are updated to pass their real validation limits: form duplication and form import use `getMaxFormHandle()`; save-as-stencil and stencil duplication use `255`, matching `Stencil`'s own handle validation rule.

Reproduced on a form whose handle was already exactly 56 characters — duplicating it threw the exception above every time. With this fix, duplication succeeds and produces a valid, unique handle.