### PR TITLE
fix: fix invalid notification handles migration 

### DIFF
--- a/src/migrations/m260710_000000_fix_invalid_notification_handles.php
+++ b/src/migrations/m260710_000000_fix_invalid_notification_handles.php
@@ -114,7 +114,7 @@ class m260710_000000_fix_invalid_notification_handles extends Migration
 
             if ($hasChanged) {
                 $this->update(Table::FORMIE_STENCILS, [
-                    'data' => $data,
+                    'data' => Json::encode($data),
                 ], ['id' => $stencil['id']], [], false);
             }
         }


### PR DESCRIPTION
Hi, i tried beta on my Craft5 which had a broken stencil, and got "Array to String conversion".
I tracked the error to a missing json_encode, which i restored.
