### PR TITLE
Active Campaign Email contact payload to use array_filter

### DIFF
--- a/src/integrations/emailmarketing/ActiveCampaign.php
+++ b/src/integrations/emailmarketing/ActiveCampaign.php
@@ -118,13 +118,13 @@ class ActiveCampaign extends EmailMarketing
             $tags = ArrayHelper::remove($fieldValues, 'tags');
 
             $payload = [
-                'contact' => [
+                'contact' => array_filter([
                     'email' => $email,
                     'firstName' => $firstName,
                     'lastName' => $lastName,
                     'phone' => $phone,
                     'fieldValues' => $this->_prepCustomFields($fieldValues),
-                ],
+                ]),
             ];
 
             $response = $this->deliverPayload($submission, 'contact/sync', $payload);


### PR DESCRIPTION
This prevents unmapped data from erasing Contact fields even when they are mapped as Don't Include in the Formie integration.

Test case for this was sending an AC CRM form integration on a form with name, email, phone fields where the data is updated correctly on the Contact and then submitting an AC email form integration where there is only an email and unexpectedly the name and phone fields were erased.

I had tested an alternative where I check that each field is explicitly mapped to a form field like below however when looking at the CRM integration for AC it just uses an `array_filter` on the `contact` value.

```
$contact = [
    'email' => $email,
];

// Only add the other fields if they are meant to be set, otherwise ActiveCampaign will blank the values
if (array_key_exists('firstName', $this->fieldMapping)) {
    $contact['firstName'] = $firstName;
}
if (array_key_exists('lastName', $this->fieldMapping)) {
    $contact['lastName'] = $lastName;
}
if (array_key_exists('phone', $this->fieldMapping)) {
    $contact['phone'] = $phone;
}

$contact['fieldValues'] = $this->_prepCustomFields($fieldValues);

$payload = [
    'contact' => $contact,
];
```

It could be argued that perhaps the AC Contact property should be blanked if a property is mapped to a form field and that value was submitted as blank and checking that the property is in the field mapping is correct way to do this however the array filtering is already being done on the CRM integration (see https://github.com/verbb/formie/blob/craft-5/src/integrations/crm/ActiveCampaign.php#L235) so consistency is probably better.